### PR TITLE
chore: fix namespace for server-init

### DIFF
--- a/charts/numaflow/templates/deployment.yaml
+++ b/charts/numaflow/templates/deployment.yaml
@@ -250,6 +250,11 @@ spec:
           image: {{ .Values.numaflow.image.repository }}:{{ .Values.numaflow.image.tag }}
           imagePullPolicy: {{ .Values.numaflow.image.pullPolicy }}
           name: server-secrets-init
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       securityContext:
         runAsNonRoot: true
         runAsUser: 9737


### PR DESCRIPTION
Fixes #4 

Add namespace env for server-secret-init container if installed in a non default namespace
```
test                 numaflow-controller-6f764f7958-zs48s         1/1     Running   0              3m1s
test                 numaflow-dex-server-c785467c7-hf6z9          1/1     Running   0              3m1s
test                 numaflow-server-97f67d6f4-xqmbr              1/1     Running   0              3m1s
test                 numaflow-webhook-74477447cc-bwzdk            1/1     Running   0              3m1s
```