### PR TITLE
Upgrade numaflow version to 1.2

### DIFF
--- a/charts/numaflow/Chart.yaml
+++ b/charts/numaflow/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2

--- a/charts/numaflow/crds/isbsvcs.yaml
+++ b/charts/numaflow/crds/isbsvcs.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: interstepbufferservices.numaflow.numaproj.io
 spec:
   group: numaflow.numaproj.io
@@ -165,6 +166,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -231,6 +242,16 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -295,6 +316,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -361,6 +392,16 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -1257,6 +1298,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -1323,6 +1374,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -1387,6 +1448,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -1453,6 +1524,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:

--- a/charts/numaflow/crds/pipelines.yaml
+++ b/charts/numaflow/crds/pipelines.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: pipelines.numaflow.numaproj.io
 spec:
   group: numaflow.numaproj.io
@@ -584,18 +585,6 @@ spec:
                                           type: object
                                         resources:
                                           properties:
-                                            claims:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                required:
-                                                  - name
-                                                type: object
-                                              type: array
-                                              x-kubernetes-list-map-keys:
-                                                - name
-                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -637,6 +626,8 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
                                           type: string
                                         volumeMode:
                                           type: string
@@ -824,6 +815,42 @@ spec:
                                 sources:
                                   items:
                                     properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
                                       configMap:
                                         properties:
                                           items:
@@ -1188,6 +1215,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -1254,6 +1291,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -1318,6 +1365,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -1384,6 +1441,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -2039,6 +2106,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -2105,6 +2182,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -2169,6 +2256,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -2235,6 +2332,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -2715,6 +2822,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -2781,6 +2898,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -2845,6 +2972,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -2911,6 +3048,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -3563,6 +3710,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -3629,6 +3786,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -3693,6 +3860,16 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             properties:
                                               matchExpressions:
@@ -3759,6 +3936,16 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -4413,6 +4600,16 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -4479,6 +4676,16 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -4543,6 +4750,16 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -4609,6 +4826,16 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -5166,6 +5393,14 @@ spec:
                                       required:
                                         - port
                                       type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                        - seconds
+                                      type: object
                                     tcpSocket:
                                       properties:
                                         host:
@@ -5215,6 +5450,14 @@ spec:
                                           type: string
                                       required:
                                         - port
+                                      type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                        - seconds
                                       type: object
                                     tcpSocket:
                                       properties:
@@ -5412,6 +5655,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                  - resourceName
+                                  - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -5443,6 +5699,8 @@ spec:
                                     x-kubernetes-int-or-string: true
                                   type: object
                               type: object
+                            restartPolicy:
+                              type: string
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -6089,6 +6347,14 @@ spec:
                                       required:
                                         - port
                                       type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                        - seconds
+                                      type: object
                                     tcpSocket:
                                       properties:
                                         host:
@@ -6138,6 +6404,14 @@ spec:
                                           type: string
                                       required:
                                         - port
+                                      type: object
+                                    sleep:
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                        - seconds
                                       type: object
                                     tcpSocket:
                                       properties:
@@ -6335,6 +6609,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                  - resourceName
+                                  - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -6366,6 +6653,8 @@ spec:
                                     x-kubernetes-int-or-string: true
                                   type: object
                               type: object
+                            restartPolicy:
+                              type: string
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -6557,6 +6846,432 @@ spec:
                         properties:
                           blackhole:
                             type: object
+                          fallback:
+                            properties:
+                              blackhole:
+                                type: object
+                              kafka:
+                                properties:
+                                  brokers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  config:
+                                    type: string
+                                  sasl:
+                                    properties:
+                                      gssapi:
+                                        properties:
+                                          authType:
+                                            type: string
+                                          kerberosConfigSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                          keytabSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                          passwordSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                          realm:
+                                            type: string
+                                          serviceName:
+                                            type: string
+                                          usernameSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                        required:
+                                          - authType
+                                          - realm
+                                          - serviceName
+                                          - usernameSecret
+                                        type: object
+                                      mechanism:
+                                        type: string
+                                      plain:
+                                        properties:
+                                          handshake:
+                                            type: boolean
+                                          passwordSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                          userSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                        required:
+                                          - handshake
+                                          - userSecret
+                                        type: object
+                                      scramsha256:
+                                        properties:
+                                          handshake:
+                                            type: boolean
+                                          passwordSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                          userSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                        required:
+                                          - handshake
+                                          - userSecret
+                                        type: object
+                                      scramsha512:
+                                        properties:
+                                          handshake:
+                                            type: boolean
+                                          passwordSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                          userSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                        required:
+                                          - handshake
+                                          - userSecret
+                                        type: object
+                                    required:
+                                      - mechanism
+                                    type: object
+                                  tls:
+                                    properties:
+                                      caCertSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      certSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      insecureSkipVerify:
+                                        type: boolean
+                                      keySecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                  topic:
+                                    type: string
+                                required:
+                                  - topic
+                                type: object
+                              log:
+                                type: object
+                              udsink:
+                                properties:
+                                  container:
+                                    properties:
+                                      args:
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        items:
+                                          properties:
+                                            configMapRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      volumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          required:
+                                            - mountPath
+                                            - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                required:
+                                  - container
+                                type: object
+                            type: object
                           kafka:
                             properties:
                               brokers:
@@ -6657,6 +7372,66 @@ spec:
                                       - handshake
                                       - userSecret
                                     type: object
+                                  scramsha256:
+                                    properties:
+                                      handshake:
+                                        type: boolean
+                                      passwordSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      userSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    required:
+                                      - handshake
+                                      - userSecret
+                                    type: object
+                                  scramsha512:
+                                    properties:
+                                      handshake:
+                                        type: boolean
+                                      passwordSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      userSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    required:
+                                      - handshake
+                                      - userSecret
+                                    type: object
                                 required:
                                   - mechanism
                                 type: object
@@ -6673,18 +7448,7 @@ spec:
                                     required:
                                       - key
                                     type: object
-                                  clientCertSecret:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  clientKeySecret:
+                                  certSecret:
                                     properties:
                                       key:
                                         type: string
@@ -6697,6 +7461,17 @@ spec:
                                     type: object
                                   insecureSkipVerify:
                                     type: boolean
+                                  keySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
                                 type: object
                               topic:
                                 type: string
@@ -6926,6 +7701,9 @@ spec:
                               duration:
                                 default: 1s
                                 type: string
+                              jitter:
+                                default: 0s
+                                type: string
                               keyCount:
                                 format: int32
                                 type: integer
@@ -7062,6 +7840,66 @@ spec:
                                       - handshake
                                       - userSecret
                                     type: object
+                                  scramsha256:
+                                    properties:
+                                      handshake:
+                                        type: boolean
+                                      passwordSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      userSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    required:
+                                      - handshake
+                                      - userSecret
+                                    type: object
+                                  scramsha512:
+                                    properties:
+                                      handshake:
+                                        type: boolean
+                                      passwordSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      userSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    required:
+                                      - handshake
+                                      - userSecret
+                                    type: object
                                 required:
                                   - mechanism
                                 type: object
@@ -7078,18 +7916,7 @@ spec:
                                     required:
                                       - key
                                     type: object
-                                  clientCertSecret:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  clientKeySecret:
+                                  certSecret:
                                     properties:
                                       key:
                                         type: string
@@ -7102,6 +7929,17 @@ spec:
                                     type: object
                                   insecureSkipVerify:
                                     type: boolean
+                                  keySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
                                 type: object
                               topic:
                                 type: string
@@ -7177,18 +8015,7 @@ spec:
                                     required:
                                       - key
                                     type: object
-                                  clientCertSecret:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  clientKeySecret:
+                                  certSecret:
                                     properties:
                                       key:
                                         type: string
@@ -7201,6 +8028,17 @@ spec:
                                     type: object
                                   insecureSkipVerify:
                                     type: boolean
+                                  keySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
                                 type: object
                               url:
                                 type: string
@@ -7916,6 +8754,8 @@ spec:
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
+                                  no_store:
+                                    type: object
                                   persistentVolumeClaim:
                                     properties:
                                       accessMode:
@@ -8181,18 +9021,6 @@ spec:
                                           type: object
                                         resources:
                                           properties:
-                                            claims:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                required:
-                                                  - name
-                                                type: object
-                                              type: array
-                                              x-kubernetes-list-map-keys:
-                                                - name
-                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -8234,6 +9062,8 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
+                                          type: string
+                                        volumeAttributesClassName:
                                           type: string
                                         volumeMode:
                                           type: string
@@ -8421,6 +9251,42 @@ spec:
                                 sources:
                                   items:
                                     properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
                                       configMap:
                                         properties:
                                           items:

--- a/charts/numaflow/crds/vertices.yaml
+++ b/charts/numaflow/crds/vertices.yaml
@@ -167,6 +167,16 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -233,6 +243,16 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                              matchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
                                 properties:
                                   matchExpressions:
@@ -297,6 +317,16 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -363,6 +393,16 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                              matchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
                                 properties:
                                   matchExpressions:
@@ -997,6 +1037,14 @@ spec:
                                 required:
                                   - port
                                 type: object
+                              sleep:
+                                properties:
+                                  seconds:
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
+                                type: object
                               tcpSocket:
                                 properties:
                                   host:
@@ -1046,6 +1094,14 @@ spec:
                                     type: string
                                 required:
                                   - port
+                                type: object
+                              sleep:
+                                properties:
+                                  seconds:
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
                                 type: object
                               tcpSocket:
                                 properties:
@@ -1243,6 +1299,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                            - resourceName
+                            - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -1274,6 +1343,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       securityContext:
                         properties:
                           allowPrivilegeEscalation:
@@ -1928,6 +1999,14 @@ spec:
                                 required:
                                   - port
                                 type: object
+                              sleep:
+                                properties:
+                                  seconds:
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
+                                type: object
                               tcpSocket:
                                 properties:
                                   host:
@@ -1977,6 +2056,14 @@ spec:
                                     type: string
                                 required:
                                   - port
+                                type: object
+                              sleep:
+                                properties:
+                                  seconds:
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
                                 type: object
                               tcpSocket:
                                 properties:
@@ -2174,6 +2261,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                            - resourceName
+                            - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -2205,6 +2305,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       securityContext:
                         properties:
                           allowPrivilegeEscalation:
@@ -2396,6 +2498,432 @@ spec:
                   properties:
                     blackhole:
                       type: object
+                    fallback:
+                      properties:
+                        blackhole:
+                          type: object
+                        kafka:
+                          properties:
+                            brokers:
+                              items:
+                                type: string
+                              type: array
+                            config:
+                              type: string
+                            sasl:
+                              properties:
+                                gssapi:
+                                  properties:
+                                    authType:
+                                      type: string
+                                    kerberosConfigSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    keytabSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    passwordSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    realm:
+                                      type: string
+                                    serviceName:
+                                      type: string
+                                    usernameSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  required:
+                                    - authType
+                                    - realm
+                                    - serviceName
+                                    - usernameSecret
+                                  type: object
+                                mechanism:
+                                  type: string
+                                plain:
+                                  properties:
+                                    handshake:
+                                      type: boolean
+                                    passwordSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    userSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  required:
+                                    - handshake
+                                    - userSecret
+                                  type: object
+                                scramsha256:
+                                  properties:
+                                    handshake:
+                                      type: boolean
+                                    passwordSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    userSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  required:
+                                    - handshake
+                                    - userSecret
+                                  type: object
+                                scramsha512:
+                                  properties:
+                                    handshake:
+                                      type: boolean
+                                    passwordSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    userSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  required:
+                                    - handshake
+                                    - userSecret
+                                  type: object
+                              required:
+                                - mechanism
+                              type: object
+                            tls:
+                              properties:
+                                caCertSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                certSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                insecureSkipVerify:
+                                  type: boolean
+                                keySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              type: object
+                            topic:
+                              type: string
+                          required:
+                            - topic
+                          type: object
+                        log:
+                          type: object
+                        udsink:
+                          properties:
+                            container:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                              - fieldPath
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                              - resource
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                              - key
+                                            type: object
+                                        type: object
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                        - type
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                      - mountPath
+                                      - name
+                                    type: object
+                                  type: array
+                              type: object
+                          required:
+                            - container
+                          type: object
+                      type: object
                     kafka:
                       properties:
                         brokers:
@@ -2496,6 +3024,66 @@ spec:
                                 - handshake
                                 - userSecret
                               type: object
+                            scramsha256:
+                              properties:
+                                handshake:
+                                  type: boolean
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                userSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              required:
+                                - handshake
+                                - userSecret
+                              type: object
+                            scramsha512:
+                              properties:
+                                handshake:
+                                  type: boolean
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                userSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              required:
+                                - handshake
+                                - userSecret
+                              type: object
                           required:
                             - mechanism
                           type: object
@@ -2512,18 +3100,7 @@ spec:
                               required:
                                 - key
                               type: object
-                            clientCertSecret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              required:
-                                - key
-                              type: object
-                            clientKeySecret:
+                            certSecret:
                               properties:
                                 key:
                                   type: string
@@ -2536,6 +3113,17 @@ spec:
                               type: object
                             insecureSkipVerify:
                               type: boolean
+                            keySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
                           type: object
                         topic:
                           type: string
@@ -2765,6 +3353,9 @@ spec:
                         duration:
                           default: 1s
                           type: string
+                        jitter:
+                          default: 0s
+                          type: string
                         keyCount:
                           format: int32
                           type: integer
@@ -2901,6 +3492,66 @@ spec:
                                 - handshake
                                 - userSecret
                               type: object
+                            scramsha256:
+                              properties:
+                                handshake:
+                                  type: boolean
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                userSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              required:
+                                - handshake
+                                - userSecret
+                              type: object
+                            scramsha512:
+                              properties:
+                                handshake:
+                                  type: boolean
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                userSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              required:
+                                - handshake
+                                - userSecret
+                              type: object
                           required:
                             - mechanism
                           type: object
@@ -2917,18 +3568,7 @@ spec:
                               required:
                                 - key
                               type: object
-                            clientCertSecret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              required:
-                                - key
-                              type: object
-                            clientKeySecret:
+                            certSecret:
                               properties:
                                 key:
                                   type: string
@@ -2941,6 +3581,17 @@ spec:
                               type: object
                             insecureSkipVerify:
                               type: boolean
+                            keySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
                           type: object
                         topic:
                           type: string
@@ -3016,18 +3667,7 @@ spec:
                               required:
                                 - key
                               type: object
-                            clientCertSecret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              required:
-                                - key
-                              type: object
-                            clientKeySecret:
+                            certSecret:
                               properties:
                                 key:
                                   type: string
@@ -3040,6 +3680,17 @@ spec:
                               type: object
                             insecureSkipVerify:
                               type: boolean
+                            keySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
                           type: object
                         url:
                           type: string
@@ -3832,6 +4483,8 @@ spec:
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
+                            no_store:
+                              type: object
                             persistentVolumeClaim:
                               properties:
                                 accessMode:
@@ -4097,18 +4750,6 @@ spec:
                                     type: object
                                   resources:
                                     properties:
-                                      claims:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                          required:
-                                            - name
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-map-keys:
-                                          - name
-                                        x-kubernetes-list-type: map
                                       limits:
                                         additionalProperties:
                                           anyOf:
@@ -4150,6 +4791,8 @@ spec:
                                         type: object
                                     type: object
                                   storageClassName:
+                                    type: string
+                                  volumeAttributesClassName:
                                     type: string
                                   volumeMode:
                                     type: string
@@ -4337,6 +4980,42 @@ spec:
                           sources:
                             items:
                               properties:
+                                clusterTrustBundle:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    signerName:
+                                      type: string
+                                  required:
+                                    - path
+                                  type: object
                                 configMap:
                                   properties:
                                     items:

--- a/charts/numaflow/templates/NOTES.txt
+++ b/charts/numaflow/templates/NOTES.txt
@@ -9,7 +9,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} numaflow-server --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.server.service.port }}
 {{- else if contains "ClusterIP" .Values.server.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=numaflow-server" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=numaflow-ux" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME $CONTAINER_PORT
   echo "Visit http://127.0.0.1:$CONTAINER_PORT to use your application"

--- a/charts/numaflow/templates/configmap.yaml
+++ b/charts/numaflow/templates/configmap.yaml
@@ -2,13 +2,18 @@ apiVersion: v1
 data:
   namespaced: {{ .Values.configs.namespacedScope | quote }}
   managed.namespace: {{ .Values.configs.managedNamespace | quote }}
-  controller.disable.leader.election: {{ .Values.controller.configs.leaderElection | quote }}
+  controller.leader.election.disabled: {{ .Values.controller.configs.leaderElection.disabled | quote }}
+  controller.leader.election.lease.duration: {{ .Values.controller.configs.leaderElection.leaseDuration | quote }}
+  controller.leader.election.lease.renew.deadline: {{ .Values.controller.configs.leaderElection.renewDuration | quote }}
+  controller.leader.election.lease.renew.period: {{ .Values.controller.configs.leaderElection.renewPeriod | quote }}
   server.insecure: {{ .Values.server.configs.insecure | quote }}
   server.port: {{ .Values.server.configs.port | quote }}
   server.base.href: {{ .Values.server.configs.baseHref | quote }}
+  server.readonly: {{ .Values.server.configs.readOnly | quote }}
   server.disable.auth: {{ .Values.server.configs.authDisable | quote }}
   server.dex.server: {{ .Values.server.configs.dexServer | quote }}
   server.address: {{ .Values.server.configs.address | quote }}
+  server.cors.allowed.origins: {{ .Values.server.configs.cors.allowedOrigin | quote }}
 kind: ConfigMap
 metadata:
   name: numaflow-cmd-params-config
@@ -19,6 +24,11 @@ metadata:
 apiVersion: v1
 data:
   controller-config.yaml: |
+    defaults:
+      containerResources: |
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
     isbsvc:
       redis:
         # Default Redis settings, could be overridden by InterStepBufferService specs
@@ -48,6 +58,11 @@ data:
             redisImage: bitnami/redis:7.0.11-debian-11-r3
             sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
             redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+            initContainerImage: debian:latest
+          - version: 7.0.15
+            redisImage: bitnami/redis:7.0.15-debian-11-r2
+            sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+            redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
             initContainerImage: debian:latest
       jetstream:
         # Default JetStream settings, could be overridden by InterStepBufferService specs
@@ -95,61 +110,66 @@ data:
             storage: 0
             replicas: 3
         versions:
-        - version: latest
-          natsImage: nats:2.10.3
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.8.1
-          natsImage: nats:2.8.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.8.1-alpine
-          natsImage: nats:2.8.1-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: nats-server
-        - version: 2.8.3
-          natsImage: nats:2.8.3
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.8.3-alpine
-          natsImage: nats:2.8.3-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: nats-server
-        - version: 2.9.0
-          natsImage: nats:2.9.0
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.9.0-alpine
-          natsImage: nats:2.9.0-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: nats-server
-        - version: 2.9.6
-          natsImage: nats:2.9.6
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.9.8
-          natsImage: nats:2.9.8
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.9.15
-          natsImage: nats:2.9.15
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.10.3
-          natsImage: nats:2.10.3
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
+          - version: latest
+            natsImage: nats:2.10.3
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.8.1
+            natsImage: nats:2.8.1
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.8.1-alpine
+            natsImage: nats:2.8.1-alpine
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: nats-server
+          - version: 2.8.3
+            natsImage: nats:2.8.3
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.8.3-alpine
+            natsImage: nats:2.8.3-alpine
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: nats-server
+          - version: 2.9.0
+            natsImage: nats:2.9.0
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.9.0-alpine
+            natsImage: nats:2.9.0-alpine
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: nats-server
+          - version: 2.9.6
+            natsImage: nats:2.9.6
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.9.8
+            natsImage: nats:2.9.8
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.9.15
+            natsImage: nats:2.9.15
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.10.3
+            natsImage: nats:2.10.3
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
+          - version: 2.10.11
+            natsImage: nats:2.10.11
+            metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+            configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+            startCommand: /nats-server
 kind: ConfigMap
 metadata:
   name: numaflow-controller-config
@@ -159,14 +179,20 @@ metadata:
 ---
 apiVersion: v1
 data:
-  config.yaml: "issuer: <HOSTNAME>/dex\nstorage:\n  type: memory\nweb:\n  http: 0.0.0.0:5556\nstaticClients:\n
-    \ - id: numaflow-server-app\n    redirectURIs: \n      - <HOSTNAME>/<base_href>/login\n
-    \   name: 'Numaflow Server App'\n    public: true\nconnectors:\n- type: github\n
-    \ # https://dexidp.io/docs/connectors/github/\n  id: github\n  name: GitHub\n
-    \ config:\n    clientID: $GITHUB_CLIENT_ID\n    clientSecret: $GITHUB_CLIENT_SECRET\n
-    \   redirectURI: <HOSTNAME>/dex/callback\n    orgs:\n    - name: <ORG_NAME>\n
-    \     teams:\n      - admin\n      - readonly\noauth2:\n  skipApprovalScreen:
-    true\n"
+  config.yaml: |-
+    connectors:
+      - type: github
+        # https://dexidp.io/docs/connectors/github/
+        id: github
+        name: GitHub
+        config:
+          clientID: $GITHUB_CLIENT_ID
+          clientSecret: $GITHUB_CLIENT_SECRET
+          orgs:
+            - name: <ORG_NAME>
+              teams:
+                - admin
+                - readonly
 kind: ConfigMap
 metadata:
   name: numaflow-dex-server-config
@@ -192,8 +218,8 @@ data:
     # We can have multiple scopes, and the first scope that matches with the policy will be used.
     # The default value is "groups", which means that the groups field of the user's token will be examined
     # The other possible value is "email", which means that the email field of the user's token will be examined
-    # It can be provided as a comma-separated list, e.g "groups,email"
-    # policy.scopes: groups,email
+    # It can be provided as a comma-separated list, e.g "groups,email,username"
+    policy.scopes: groups,email,username
   rbac-policy.csv: |
     # Policies go here
     p, role:admin, *, *, *

--- a/charts/numaflow/templates/deployment.yaml
+++ b/charts/numaflow/templates/deployment.yaml
@@ -25,10 +25,6 @@ spec:
           env:
             - name: NUMAFLOW_IMAGE
               value: {{ .Values.numaflow.image.repository }}:{{ .Values.numaflow.image.tag }}
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: NUMAFLOW_CONTROLLER_NAMESPACED
               valueFrom:
                 configMapKeyRef:
@@ -44,7 +40,25 @@ spec:
             - name: NUMAFLOW_LEADER_ELECTION_DISABLED
               valueFrom:
                 configMapKeyRef:
-                  key: controller.disable.leader.election
+                  key: controller.leader.election.disabled
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.duration
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.deadline
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.period
                   name: numaflow-cmd-params-config
                   optional: true
           image: {{ .Values.numaflow.image.repository }}:{{ .Values.numaflow.image.tag }}
@@ -118,8 +132,41 @@ spec:
           ports:
             - containerPort: 5556
           volumeMounts:
-            - mountPath: /etc/numaflow/dex/cfg
-              name: config
+          - mountPath: /etc/numaflow/dex/cfg/config.yaml
+            name: generated-dex-config
+            subPath: config.yaml
+          - mountPath: /etc/numaflow/dex/tls/tls.crt
+            name: tls
+            subPath: tls.crt
+          - mountPath: /etc/numaflow/dex/tls/tls.key
+            name: tls
+            subPath: tls.key
+      initContainers:
+        - args:
+            - dex-server-init
+          env:
+            - name: NUMAFLOW_SERVER_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  key: server.address
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_SERVER_BASE_HREF
+              valueFrom:
+                configMapKeyRef:
+                  key: server.base.href
+                  name: numaflow-cmd-params-config
+                  optional: true
+          image: {{ .Values.numaflow.image.repository }}:{{ .Values.numaflow.image.tag }}
+          imagePullPolicy: {{ .Values.numaflow.image.pullPolicy }}
+          name: dex-init
+          volumeMounts:
+            - mountPath: /cfg
+              name: connector-config
+            - mountPath: /tls
+              name: tls
+            - mountPath: /tmp
+              name: generated-dex-config
       serviceAccountName: numaflow-dex-server
       volumes:
         - configMap:
@@ -127,7 +174,11 @@ spec:
               - key: config.yaml
                 path: config.yaml
             name: numaflow-dex-server-config
-          name: config
+          name: connector-config
+        - emptyDir: {}
+          name: tls
+        - emptyDir: {}
+          name: generated-dex-config
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -140,14 +191,14 @@ spec:
   replicas: {{ .Values.server.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: ux-server
-      app.kubernetes.io/name: numaflow-server
+      app.kubernetes.io/component: numaflow-ux
+      app.kubernetes.io/name: numaflow-ux
       app.kubernetes.io/part-of: numaflow
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: ux-server
-        app.kubernetes.io/name: numaflow-server
+        app.kubernetes.io/component: numaflow-ux
+        app.kubernetes.io/name: numaflow-ux
         app.kubernetes.io/part-of: numaflow
     spec:
       containers:
@@ -188,6 +239,12 @@ spec:
                   key: server.base.href
                   name: numaflow-cmd-params-config
                   optional: true
+            - name: NUMAFLOW_SERVER_READONLY
+              valueFrom:
+                configMapKeyRef:
+                  key: server.readonly
+                  name: numaflow-cmd-params-config
+                  optional: true
             - name: NUMAFLOW_SERVER_DISABLE_AUTH
               valueFrom:
                 configMapKeyRef:
@@ -204,6 +261,12 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   key: server.address
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
+              valueFrom:
+                configMapKeyRef:
+                  key: server.cors.allowed.origins
                   name: numaflow-cmd-params-config
                   optional: true
           image: {{ .Values.numaflow.image.repository }}:{{ .Values.numaflow.image.tag }}
@@ -255,6 +318,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: NUMAFLOW_SERVER_DISABLE_AUTH
+              valueFrom:
+                configMapKeyRef:
+                  key: server.disable.auth
+                  name: numaflow-cmd-params-config
+                  optional: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 9737

--- a/charts/numaflow/templates/role.yaml
+++ b/charts/numaflow/templates/role.yaml
@@ -180,7 +180,6 @@ rules:
       - events
       - pods
       - pods/log
-      - pods/exec
       - configmaps
       - services
       - persistentvolumeclaims

--- a/charts/numaflow/templates/rolebinding.yaml
+++ b/charts/numaflow/templates/rolebinding.yaml
@@ -92,8 +92,8 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "numaflow.labels" . | nindent 4 }}
-    app.kubernetes.io/component: ux-server
-    app.kubernetes.io/name: numaflow-server
+    app.kubernetes.io/component: numaflow-ux
+    app.kubernetes.io/name: numaflow-ux
     app.kubernetes.io/part-of: numaflow
   name: numaflow-server-binding
 roleRef:

--- a/charts/numaflow/templates/service.yaml
+++ b/charts/numaflow/templates/service.yaml
@@ -26,8 +26,8 @@ spec:
     - port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.port }}
   selector:
-    app.kubernetes.io/component: ux-server
-    app.kubernetes.io/name: numaflow-server
+    app.kubernetes.io/component: numaflow-ux
+    app.kubernetes.io/name: numaflow-ux
     app.kubernetes.io/part-of: numaflow
   type: {{ .Values.server.service.type }}
 

--- a/charts/numaflow/values.yaml
+++ b/charts/numaflow/values.yaml
@@ -7,7 +7,7 @@ numaflow:
     # -- Image of numaflow server.
     repository: quay.io/numaproj/numaflow
     # -- Tag of numaflow server.
-    tag: v1.1.1
+    tag: v1.2.1
     # -- Image Pull policy of numaflow server.
     pullPolicy: Always
 
@@ -41,12 +41,17 @@ server:
     port: 8443
     # -- Base href for Numaflow UX server, defaults to '/'.
     baseHref: /
-    # -- Whether to disable authentication and authorization for the UX server, defaults to false.
-    authDisable: false
+    # -- Whether to enable read only view for the UX server, defaults to false.
+    readOnly: "false"
+    # -- Whether to disable authentication and authorization for the UX server, defaults to true.
+    authDisable: "true"
     # -- The address of the Dex server for authentication.
     dexServer: http://numaflow-dex-server:5556/dex
     # -- The external address of the Numaflow server. This is needed when using Dex for authentication.
     address: https://localhost:8443
+    # -- The list of allowed origins for CORS on Numaflow server, separated by a comma, defaults to ''. For example: server.cors.allowed.origins: "http://localhost:3000,http://localhost:3001"
+    cors:
+      allowedOrigin: ""
   service:
     # -- The type of service for the numaflow server.
     type: ClusterIP
@@ -75,7 +80,12 @@ controller:
   replicaCount: 1
   configs:
     # -- Whether to disable leader election for the controller, defaults to false
-    leaderElection: false
+    leaderElection:
+      disabled: false
+      leaseDuration: 15s
+      renewDuration: 10s
+      renewPeriod: 2s
+
   resources:
     limits:
       # -- The CPU limits for controller.


### PR DESCRIPTION
fixes: #7 

Verified the changes with below command

```bash
$ helm install numaflow --namespace numaflow-system .
NAME: numaflow
LAST DEPLOYED: Tue May  7 21:42:30 2024
NAMESPACE: numaflow-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace numaflow-system -l "app.kubernetes.io/name=numaflow-ux" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace numaflow-system $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
  kubectl --namespace numaflow-system port-forward $POD_NAME $CONTAINER_PORT
  echo "Visit http://127.0.0.1:$CONTAINER_PORT to use your application"
```

Output:
```bash
$ k get po -n numaflow-system
NAME                                   READY   STATUS    RESTARTS   AGE
numaflow-controller-6cdb7df867-ghs6p   1/1     Running   0          3m56s
numaflow-dex-server-56c5d5546b-l2fzq   1/1     Running   0          3m56s
numaflow-server-56b5db4f54-lmlqj       1/1     Running   0          3m56s
numaflow-webhook-54f5848fb8-6wgpw      1/1     Running   0          3m56s
```
