### PR TITLE
Fix the port configuration for insecure server

### DIFF
--- a/charts/numaflow/templates/NOTES.txt
+++ b/charts/numaflow/templates/NOTES.txt
@@ -7,7 +7,7 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w numaflow-server'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} numaflow-server --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.server.service.port }}
+  echo http://$SERVICE_IP:{{ include "server.configs.port" . }}
 {{- else if contains "ClusterIP" .Values.server.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=numaflow-ux" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/charts/numaflow/templates/_helpers.tpl
+++ b/charts/numaflow/templates/_helpers.tpl
@@ -13,3 +13,10 @@ helm.sh/chart: {{ include "numaflow.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "server.configs.port" -}}
+{{- if .Values.server.configs.insecure -}}
+{{- .Values.server.configs.insecurePort}}
+{{- else -}}
+{{- .Values.server.configs.port }}
+{{- end -}}
+{{- end -}}

--- a/charts/numaflow/templates/configmap.yaml
+++ b/charts/numaflow/templates/configmap.yaml
@@ -7,12 +7,12 @@ data:
   controller.leader.election.lease.renew.deadline: {{ .Values.controller.configs.leaderElection.renewDuration | quote }}
   controller.leader.election.lease.renew.period: {{ .Values.controller.configs.leaderElection.renewPeriod | quote }}
   server.insecure: {{ .Values.server.configs.insecure | quote }}
-  server.port: {{ .Values.server.configs.port | quote }}
+  server.port: "{{ include "server.configs.port" . }}"
   server.base.href: {{ .Values.server.configs.baseHref | quote }}
   server.readonly: {{ .Values.server.configs.readOnly | quote }}
   server.disable.auth: {{ .Values.server.configs.authDisable | quote }}
   server.dex.server: {{ .Values.server.configs.dexServer | quote }}
-  server.address: {{ .Values.server.configs.address | quote }}
+  server.address: "{{ .Values.server.configs.host }}:{{ include "server.configs.port" . }}"
   server.cors.allowed.origins: {{ .Values.server.configs.cors.allowedOrigin | quote }}
 kind: ConfigMap
 metadata:

--- a/charts/numaflow/templates/deployment.yaml
+++ b/charts/numaflow/templates/deployment.yaml
@@ -272,12 +272,16 @@ spec:
           image: {{ .Values.numaflow.image.repository }}:{{ .Values.numaflow.image.tag }}
           imagePullPolicy: {{ .Values.numaflow.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.server.service.port }}
+            - containerPort: {{ include "server.configs.port" . }}
           livenessProbe:
             httpGet:
               path: /livez
-              port: 8443
+              port: {{ include "server.configs.port" . }}
+              {{- if .Values.server.configs.insecure }}
+              scheme: HTTP
+              {{- else }}
               scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 3
             periodSeconds: 3
           name: main

--- a/charts/numaflow/templates/service.yaml
+++ b/charts/numaflow/templates/service.yaml
@@ -23,8 +23,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-    - port: {{ .Values.server.service.port }}
-      targetPort: {{ .Values.server.service.port }}
+    - port: {{ include "server.configs.port" . }}
+      targetPort: {{ include "server.configs.port" . }}
   selector:
     app.kubernetes.io/component: numaflow-ux
     app.kubernetes.io/name: numaflow-ux

--- a/charts/numaflow/values.yaml
+++ b/charts/numaflow/values.yaml
@@ -37,7 +37,9 @@ server:
   configs:
     # -- Whether to disable TLS for UX server.
     insecure: false
-    # -- Port to listen on for UX server, defaults to 8443 or 8080 if insecure is set.
+    # -- insecurePort to listen for UX server if insecure is set true, default to 8080.
+    insecurePort: 8080
+    # -- Port to listen on for UX server, defaults to 8443.
     port: 8443
     # -- Base href for Numaflow UX server, defaults to '/'.
     baseHref: /
@@ -48,15 +50,13 @@ server:
     # -- The address of the Dex server for authentication.
     dexServer: http://numaflow-dex-server:5556/dex
     # -- The external address of the Numaflow server. This is needed when using Dex for authentication.
-    address: https://localhost:8443
+    host: localhost
     # -- The list of allowed origins for CORS on Numaflow server, separated by a comma, defaults to ''. For example: server.cors.allowed.origins: "http://localhost:3000,http://localhost:3001"
     cors:
       allowedOrigin: ""
   service:
     # -- The type of service for the numaflow server.
     type: ClusterIP
-    # -- The port of the numaflow server.
-    port: 8443
 
 dexServer:
   image:


### PR DESCRIPTION
Fixes: https://github.com/numaproj/helm-charts/issues/10

Have verified for below cases:

case 1: With setting `server.configs.insecure` as "true"
```bash
**installing numaflow**
$ helm install numaflow . --set server.configs.insecure="true" --namespace numaflow-system --create-namespace
NAME: numaflow
LAST DEPLOYED: Mon May 20 23:12:46 2024
NAMESPACE: numaflow-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace numaflow-system -l "app.kubernetes.io/name=numaflow-ux" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace numaflow-system $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
  kubectl --namespace numaflow-system port-forward $POD_NAME $CONTAINER_PORT
  echo "Visit http://127.0.0.1:$CONTAINER_PORT to use your application"



**Configmap info:**
 $ kubectl get cm -n numaflow-system numaflow-cmd-params-config -o yaml
apiVersion: v1
data:
....
  server.disable.auth: "true"
  server.insecure: "true"
  server.port: "8080"
  server.readonly: "false"
kind: ConfigMap
metadata:
...


**numaflow-server deployment info**
$ kubectl get deploy numaflow-server -n numaflow-system -o yaml
.....
 livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /livez
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 3
          periodSeconds: 3
          successThreshold: 1
          timeoutSeconds: 1
        name: main
        ports:
        - containerPort: 8080
          protocol: TCP
.....
```

Case 2: With setting `server.configs.insecure` as "false"
```bash
$ helm install numaflow .  --namespace numaflow-system --create-namespace
NAME: numaflow
LAST DEPLOYED: Mon May 20 23:19:54 2024
NAMESPACE: numaflow-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace numaflow-system -l "app.kubernetes.io/name=numaflow-ux" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace numaflow-system $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
  kubectl --namespace numaflow-system port-forward $POD_NAME $CONTAINER_PORT
  echo "Visit http://127.0.0.1:$CONTAINER_PORT to use your application"



**Configmap info:**
$ kubectl get cm -n numaflow-system numaflow-cmd-params-config -o yaml
.....
  server.insecure: "false"
  server.port: "8443"
  server.readonly: "false"
.....


**numaflow-server deployment info**
$ kubectl get cm -n numaflow-system numaflow-cmd-params-config -o yaml
....
livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /livez
            port: 8443
            scheme: HTTPS
          initialDelaySeconds: 3
          periodSeconds: 3
          successThreshold: 1
          timeoutSeconds: 1
        name: main
        ports:
        - containerPort: 8443
          protocol: TCP
.....

```