### PR TITLE
fix: Add Numaflow app version in helm chart

### DIFF
--- a/charts/numaflow/Chart.yaml
+++ b/charts/numaflow/Chart.yaml
@@ -15,6 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.3.3"
 maintainers:
   - name: chandankumar4


### PR DESCRIPTION
Fix: #15 

```bash
$ helm ls -A                                                            
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
numaflow        numaflow-system 1               2024-10-23 19:02:37.635594 +0530 IST    deployed        numaflow-0.0.4  1.3.3 
```