### PR TITLE
Removing extra break point

### DIFF
--- a/charts/numaflow/templates/role.yaml
+++ b/charts/numaflow/templates/role.yaml
@@ -214,7 +214,6 @@ rules:
       - watch
 ---
 {{- else }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
There was an extra breakpoint in role.yaml. This causes some linters and parsers to complain. 