### PR TITLE
Update helm chart for Numaflow version 1.4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-SHELL:=/bin/bash
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
 
-# Latest version of Numaflow
-NUMAFLOW_VERSION=v1.4.0
+# Check if NUMAFLOW_VERSION is set, if not, then echo message about set it
+ifndef NUMAFLOW_VERSION
+$(error NUMAFLOW_VERSION is not set. Please set it to the version you want to release, for example: v1.4.0)
+endif
 
 # Update the numaflow CRDs
 .PHONY: update-crds

--- a/charts/numaflow/Chart.yaml
+++ b/charts/numaflow/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.4.0"
+appVersion: "1.4.4"
 maintainers:
   - name: chandankumar4

--- a/charts/numaflow/crds/monovertices.yaml
+++ b/charts/numaflow/crds/monovertices.yaml
@@ -3474,6 +3474,41 @@ spec:
                                 type: object
                               mechanism:
                                 type: string
+                              oauth:
+                                properties:
+                                  clientID:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  clientSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  tokenEndpoint:
+                                    type: string
+                                required:
+                                - clientID
+                                - clientSecret
+                                - tokenEndpoint
+                                type: object
                               plain:
                                 properties:
                                   handshake:
@@ -4009,6 +4044,41 @@ spec:
                             type: object
                           mechanism:
                             type: string
+                          oauth:
+                            properties:
+                              clientID:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              clientSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              tokenEndpoint:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecret
+                            - tokenEndpoint
+                            type: object
                           plain:
                             properties:
                               handshake:
@@ -4723,6 +4793,41 @@ spec:
                             type: object
                           mechanism:
                             type: string
+                          oauth:
+                            properties:
+                              clientID:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              clientSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              tokenEndpoint:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecret
+                            - tokenEndpoint
+                            type: object
                           plain:
                             properties:
                               handshake:

--- a/charts/numaflow/crds/pipelines.yaml
+++ b/charts/numaflow/crds/pipelines.yaml
@@ -108,7 +108,11 @@ spec:
                 properties:
                   deleteGracePeriodSeconds:
                     default: 30
-                    format: int32
+                    format: int64
+                    type: integer
+                  deletionGracePeriodSeconds:
+                    default: 30
+                    format: int64
                     type: integer
                   desiredPhase:
                     default: Running
@@ -122,7 +126,7 @@ spec:
                     type: string
                   pauseGracePeriodSeconds:
                     default: 30
-                    format: int32
+                    format: int64
                     type: integer
                 type: object
               limits:
@@ -8154,6 +8158,41 @@ spec:
                                       type: object
                                     mechanism:
                                       type: string
+                                    oauth:
+                                      properties:
+                                        clientID:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        clientSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        tokenEndpoint:
+                                          type: string
+                                      required:
+                                      - clientID
+                                      - clientSecret
+                                      - tokenEndpoint
+                                      type: object
                                     plain:
                                       properties:
                                         handshake:
@@ -8689,6 +8728,41 @@ spec:
                                   type: object
                                 mechanism:
                                   type: string
+                                oauth:
+                                  properties:
+                                    clientID:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    clientSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    tokenEndpoint:
+                                      type: string
+                                  required:
+                                  - clientID
+                                  - clientSecret
+                                  - tokenEndpoint
+                                  type: object
                                 plain:
                                   properties:
                                     handshake:
@@ -9403,6 +9477,41 @@ spec:
                                   type: object
                                 mechanism:
                                   type: string
+                                oauth:
+                                  properties:
+                                    clientID:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    clientSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    tokenEndpoint:
+                                      type: string
+                                  required:
+                                  - clientID
+                                  - clientSecret
+                                  - tokenEndpoint
+                                  type: object
                                 plain:
                                   properties:
                                     handshake:

--- a/charts/numaflow/crds/vertices.yaml
+++ b/charts/numaflow/crds/vertices.yaml
@@ -1758,6 +1758,19 @@ spec:
                 type: array
               interStepBufferServiceName:
                 type: string
+              lifecycle:
+                default:
+                  desiredPhase: Running
+                properties:
+                  desiredPhase:
+                    default: Running
+                    enum:
+                    - ""
+                    - Running
+                    - Paused
+                    - Failed
+                    type: string
+                type: object
               limits:
                 properties:
                   bufferMaxLength:
@@ -2942,6 +2955,41 @@ spec:
                                 type: object
                               mechanism:
                                 type: string
+                              oauth:
+                                properties:
+                                  clientID:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  clientSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  tokenEndpoint:
+                                    type: string
+                                required:
+                                - clientID
+                                - clientSecret
+                                - tokenEndpoint
+                                type: object
                               plain:
                                 properties:
                                   handshake:
@@ -3477,6 +3525,41 @@ spec:
                             type: object
                           mechanism:
                             type: string
+                          oauth:
+                            properties:
+                              clientID:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              clientSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              tokenEndpoint:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecret
+                            - tokenEndpoint
+                            type: object
                           plain:
                             properties:
                               handshake:
@@ -4191,6 +4274,41 @@ spec:
                             type: object
                           mechanism:
                             type: string
+                          oauth:
+                            properties:
+                              clientID:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              clientSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              tokenEndpoint:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecret
+                            - tokenEndpoint
+                            type: object
                           plain:
                             properties:
                               handshake:
@@ -6456,6 +6574,7 @@ spec:
                 enum:
                 - ""
                 - Running
+                - Paused
                 - Failed
                 type: string
               readyReplicas:

--- a/charts/numaflow/templates/configmap.yaml
+++ b/charts/numaflow/templates/configmap.yaml
@@ -250,10 +250,86 @@ data:
     # example for local prometheus service
     # url: http://prometheus-operated.monitoring.svc.cluster.local:9090
     patterns:
+      - name: vertex_gauge
+        objects:
+          - vertex
+        title: Vertex Gauge Metrics
+        description: This pattern represents the gauge metrics for a vertex across different dimensions
+        expr: |
+          sum($metric_name{$filters}) by ($dimension, period)
+        params:
+          - name: start_time
+            required: false
+          - name: end_time
+            required: false
+        metrics:
+          - metric_name: vertex_pending_messages
+            display_name: Vertex Pending Messages
+            metric_description: This gauge metric keeps track of the total number of messages that are waiting to be processed over varying time frames of 1min, 5min, 15min and default period of 2min.
+            # set "Units" or unset for default behaviour
+            # unit: Units
+            required_filters:
+              - namespace
+              - pipeline
+              - vertex
+            dimensions:
+              - name: pod
+                # expr: optional expression for prometheus query
+                # overrides the default expression
+                filters:
+                  - name: pod
+                    required: false
+                  - name: period
+                    required: false
+              - name: vertex
+                # expr: optional expression for prometheus query
+                # overrides the default expression
+                filters:
+                  - name: period
+                    required: false
+
+      - name: mono_vertex_gauge
+        objects:
+          - mono-vertex
+        title: MonoVertex Gauge Metrics
+        description: This pattern represents the gauge metrics for a mono-vertex across different dimensions
+        expr: |
+          sum($metric_name{$filters}) by ($dimension, period)
+        params:
+          - name: start_time
+            required: false
+          - name: end_time
+            required: false
+        metrics:
+          - metric_name: monovtx_pending
+            display_name: MonoVertex Pending Messages
+            metric_description: This gauge metric keeps track of the total number of messages that are waiting to be processed over varying time frames of 1min, 5min, 15min and default period of 2min.
+            # set "Units" or unset for default behaviour
+            # unit: Units
+            required_filters:
+              - namespace
+              - mvtx_name
+            dimensions:
+              - name: pod
+                # expr: optional expression for prometheus query
+                # overrides the default expression
+                filters:
+                  - name: pod
+                    required: false
+                  - name: period
+                    required: false
+              - name: mono-vertex
+                # expr: optional expression for prometheus query
+                # overrides the default expression
+                filters:
+                  - name: period
+                    required: false
+
       - name: mono_vertex_histogram
-        object: mono-vertex
-        title: Processing Time Latency
-        description: This query pattern is for P99,P90 and P50 quantiles for a mono-vertex across different dimensions
+        objects:
+          - mono-vertex
+        title: MonoVertex Histogram Metrics
+        description: This pattern is for P99, P95, P90 and P50 quantiles for a mono-vertex across different dimensions
         expr: |
           histogram_quantile($quantile, sum by($dimension,le) (rate($metric_name{$filters}[$duration])))
         params:
@@ -267,32 +343,204 @@ data:
             required: false
         metrics:
           - metric_name: monovtx_processing_time_bucket
+            display_name: MonoVertex Processing Time Latency
+            metric_description: This metric represents a histogram to keep track of the total time taken to forward a chunk of messages.
+            # set "Units" or unset for default behaviour otherwise set "s" or "ms" for latency metrics
+            # Note: latency values are in μs
+            # unit: s
             required_filters:
               - namespace
               - mvtx_name
             dimensions:
+              - name: mono-vertex
               - name: pod
-                # expr: optional expression for prometheus query
-                # overrides the default expression
                 filters:
                   - name: pod
                     required: false
+          - metric_name: monovtx_sink_time_bucket
+            display_name: MonoVertex Sink Write Time Latency
+            metric_description: This metric represents a histogram to keep track of the total time taken to write to the Sink.
+            # set "Units" or unset for default behaviour otherwise set "s" or "ms" for latency metrics
+            # Note: latency values are in μs
+            # unit: ms
+            required_filters:
+              - namespace
+              - mvtx_name
+            dimensions:
               - name: mono-vertex
-                # expr: optional expression for prometheus query
-                # overrides the default expression
-          # Add histogram metrics similar to the pattern above
-          #- metric_name: monovtx_sink_time_bucket
-          #  required_filters:
-          #    - namespace
-          #    - mvtx_name
-          #  dimensions:
-          #    - name: pod
-          #      #expr: optional
-          #      filters:
-          #        - name: pod
-          #          required: false
-          #    - name: mono-vertex
-          #      #expr: optional
+              - name: pod
+                filters:
+                  - name: pod
+                    required: false
+
+      - name: vertex_throughput
+        objects:
+          - vertex
+        title: Vertex Throughput and Message Rates
+        description: This pattern measures the throughput of a vertex in messages per second across different dimensions
+        expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+        params:
+          - name: duration
+            required: true
+          - name: start_time
+            required: false
+          - name: end_time
+            required: false
+        metrics:
+          - metric_name: forwarder_data_read_total
+            display_name: Vertex Read Processing Rate
+            metric_description: This metric represents the total number of data messages read per second.
+            # set "Units" or unset for default behaviour
+            # unit: Units
+            required_filters:
+              - namespace
+              - pipeline
+              - vertex
+            dimensions:
+              - name: vertex
+              - name: pod
+                filters:
+                  - name: pod
+                    required: false
+
+      - name: mono_vertex_throughput
+        objects:
+          - mono-vertex
+        title: MonoVertex Throughput and Message Rates
+        description: This pattern measures the throughput of a MonoVertex in messages per second across different dimensions.
+        expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+        params:
+          - name: duration
+            required: true
+          - name: start_time
+            required: false
+          - name: end_time
+            required: false
+        metrics:
+          - metric_name: monovtx_read_total
+            display_name: MonoVertex Read Processing Rate
+            metric_description: This metric represents the total number of data messages read per second.
+            # set "Units" or unset for default behaviour
+            # unit: Units
+            required_filters:
+              - namespace
+              - mvtx_name
+            dimensions:
+              - name: mono-vertex
+              - name: pod
+                filters:
+                  - name: pod
+                    required: false
+
+      - name: pod_cpu_memory_utilization
+        objects:
+          - mono-vertex
+          - vertex
+        title: CPU and Memory Utilisation by Pod
+        description: This pattern represents the CPU and Memory utilisation by pod for mono-vertex and vertex
+        expr: avg_over_time($metric_name{$filters}[$duration])
+        params:
+          - name: duration
+            required: true
+          - name: start_time
+            required: false
+          - name: end_time
+            required: false
+        metrics:
+          # set your cpu metric name here
+          - metric_name: namespace_pod_cpu_utilization
+            display_name: Pod CPU Utilization
+            metric_description: This metric represents the percentage utilization of cpu usage over cpu resource limits for a pod.
+            required_filters:
+              - namespace
+              - pod
+            dimensions:
+              - name: mono-vertex
+                filters:
+                  - name: pod
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
+              - name: vertex
+                filters:
+                  - name: pod
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
+          # set your memory metric name here
+          - metric_name: namespace_pod_memory_utilization
+            display_name: Pod Memory Utilization
+            metric_description: This metric represents the percentage utilization of memory usage in bytes over memory resource limits for a pod.
+            required_filters:
+              - namespace
+              - pod
+            dimensions:
+              - name: mono-vertex
+                filters:
+                  - name: pod
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
+              - name: vertex
+                filters:
+                  - name: pod
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
+
+      - name: container_cpu_memory_utilization
+        objects:
+          - mono-vertex
+          - vertex
+        title: CPU and Memory Utilisation by Container
+        description: This pattern represents the CPU and Memory utilisation by container for mono-vertex and vertex
+        expr: avg_over_time($metric_name{$filters}[$duration])
+        params:
+          - name: duration
+            required: true
+          - name: start_time
+            required: false
+          - name: end_time
+            required: false
+        metrics:
+          # set your cpu metric name here
+          - metric_name: namespace_app_container_cpu_utilization
+            display_name: Container CPU Utilization
+            metric_description: This metric represents the percentage utilization of cpu usage over cpu resource limits for a container.
+            required_filters:
+              - namespace
+            dimensions:
+              - name: mono-vertex
+                filters:
+                  - name: container
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
+              - name: vertex
+                filters:
+                  - name: container
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
+          # set your memory metric name here
+          - metric_name: namespace_app_container_memory_utilization
+            display_name: Container Memory Utilization
+            metric_description: This metric represents the percentage utilization of memory usage in bytes over memory resource limits for a container.
+            required_filters:
+              - namespace
+            dimensions:
+              - name: mono-vertex
+                filters:
+                  - name: container
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
+              - name: vertex
+                filters:
+                  - name: container
+                    # expr: optional expression for prometheus query
+                    # overrides the default expression
+                    required: false
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/charts/numaflow/values.yaml
+++ b/charts/numaflow/values.yaml
@@ -7,7 +7,7 @@ numaflow:
     # -- Image of numaflow server.
     repository: quay.io/numaproj/numaflow
     # -- Tag of numaflow server.
-    tag: v1.4.0
+    tag: v1.4.4
     # -- Image Pull policy of numaflow server.
     pullPolicy: Always
 


### PR DESCRIPTION
Fixes: https://github.com/numaproj/helm-charts/issues/27

Verfied on local k8s cluster

```bash
$ helm install numaflow charts/numaflow --namespace numaflow-system --create-namespace
NAME: numaflow
LAST DEPLOYED: Fri Apr 11 15:16:35 2025
NAMESPACE: numaflow-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  kubectl --namespace numaflow-system port-forward svc/numaflow-server 8443
  echo "Visit https://127.0.0.1:8443 to use your application"
```

```bash
$ k get po -n numaflow-system
NAME                                  READY   STATUS    RESTARTS   AGE
numaflow-controller-b98f87987-k8lf2   1/1     Running   0          9m50s
numaflow-dex-server-c766bd945-7rnpz   1/1     Running   0          9m50s
numaflow-server-98d49f88b-6f58d       1/1     Running   0          9m50s
numaflow-webhook-f54f967bf-6w4dr      1/1     Running   0          9m50s
```

Tested with example pipelines
```bash
default           isbsvc-default-js-0                       3/3     Running   0          10m
default           isbsvc-default-js-1                       3/3     Running   0          10m
default           isbsvc-default-js-2                       3/3     Running   0          10m
default           simple-pipeline-cat-0-0feic               2/2     Running   0          7m4s
default           simple-pipeline-daemon-758d7d874b-jh992   1/1     Running   0          8m43s
default           simple-pipeline-in-0-hur8v                1/1     Running   0          7m4s
default           simple-pipeline-out-0-zyorp               1/1     Running   0          7m4
```

Numaflow UI with Running pipeline and their Pod view
<img width="1728" alt="Screenshot 2025-04-11 at 15 31 29" src="https://github.com/user-attachments/assets/7ef82788-d4a1-49dd-ba06-df6f9f853801" />
