### PR TITLE
Upgrade numaflow version to v1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The released chart versions and related Numaflow app versions are:
 
 ```text
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
+numaproj/numaflow       0.2.1           1.5.1           A Helm chart for installing Numaflow in Kubernetes
 numaproj/numaflow       0.2.0           1.5.0           A Helm chart for installing Numaflow in Kubernetes
 numaproj/numaflow       0.0.7           1.4.4           A Helm chart for installing Numaflow in Kubernetes
 numaproj/numaflow       0.0.6           1.4.0           A Helm chart for installing Numaflow in Kubernetes

--- a/charts/numaflow/Chart.yaml
+++ b/charts/numaflow/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.5.0
+appVersion: 1.5.1
 description: A Helm chart for installing Numaflow in Kubernetes
 maintainers:
 - name: chandankumar4
 name: numaflow
 type: application
-version: 0.2.0
+version: 0.2.1

--- a/charts/numaflow/values.yaml
+++ b/charts/numaflow/values.yaml
@@ -7,7 +7,7 @@ numaflow:
     # -- Image of numaflow server.
     repository: quay.io/numaproj/numaflow
     # -- Tag of numaflow server.
-    tag: v1.5.0
+    tag: v1.5.1
     # -- Image Pull policy of numaflow server.
     pullPolicy: Always
 


### PR DESCRIPTION
Verified in local k8s cluster:
```
$ helm install numaflow charts/numaflow --namespace numaflow-system --create-namespace

NAME: numaflow
LAST DEPLOYED: Thu Jul 10 16:32:22 2025
NAMESPACE: numaflow-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  kubectl --namespace numaflow-system port-forward svc/numaflow-server 8443
  echo "Visit https://127.0.0.1:8443 to use your application"
```