### PR TITLE
feat: helpers to reduce manual comparisons during upgrades

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,49 +2,52 @@
 
 This repository contains the Helm charts for deploying Numaflow. As the Numaflow project evolves with new versions, updates to this Helm chart may be necessary to accommodate new features, improvements, or breaking changes.
 
-> **Note:** This repo contains the partial automation which helps in updating the helm chart for new numaflow versions.
-Like updating the CRDs, RBAC, ServiceAccount. The rest of the files (Deployments, Secrets, Services and Configmaps) need to be updated manually by comparing it with the current version of numaflow.
+> **Note:** Releasing a new helm chart is partially automated. `make upgrade-charts` refreshes Chart.yaml, values.yaml, CRDs, RBAC, and ServiceAccounts; `make sync-mirrored-files` handles the configmaps, deployments, secrets, and services that previously had to be hand-diffed.
 
 ## Updating Helm Chart for New Numaflow Versions
 
-**Step 1:**
-- Update Numaflow CRDs, RBACs and ServiceAccounts. This will also upgrade the version and AppVersion in the `Chart.yaml` file.
+**Step 1: refresh auto-managed files**
+
 ```
-NUMAFLOW_VERSION=v1.4.4 make upgrade-charts
+NUMAFLOW_VERSION=vx.y.z make upgrade-charts
 ```
 
-**Step 3:**
-- Update these file changes accordingly by comparing it with the current Numaflow Version. (Note: All below examples are based on `v1.5.1` version of Numaflow, So change the version accordingly while comparing)
-  - Update the [configmaps](charts/numaflow/templates/configmaps)
-    - File [numaflow-cmd-params-config.yaml](charts/numaflow/templates/configmaps/numaflow-cmd-params-config.yaml) should be updated with numaflow [numaflow-cmd-params-config.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/shared-config/numaflow-cmd-params-config.yaml)
-    - File [numaflow-server-metrics-proxy-config.yaml](charts/numaflow/templates/configmaps/numaflow-server-metrics-proxy-config.yaml) should be updated with [numaflow-server-metrics-proxy-config.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml)
-    - File [numaflow-controller-config.yaml](charts/numaflow/templates/configmaps/numaflow-controller-config.yaml) should be updated with [numaflow-controller-config.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/controller-manager/numaflow-controller-config.yaml)
-    - File [numaflow-dex-server-config.yaml](charts/numaflow/templates/configmaps/numaflow-dex-server-config.yaml) should be updated with [numaflow-dex-server-config.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/dex/numaflow-dex-server-configmap.yaml)
-    - File [numaflow-server-local-uer-config.yaml](charts/numaflow/templates/configmaps/numaflow-server-local-user-config.yaml) should be updated with [numaflow-server-local-user-config.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/numaflow-server/numaflow-server-local-user-config.yaml)
-    - File [numaflow-server-rbac-config.yaml](charts/numaflow/templates/configmaps/numaflow-server-rbac-config.yaml) should be updated with [numaflow-server-rbac-config.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/numaflow-server/numaflow-server-rbac-config.yaml)
-  - Update the [deployments](charts/numaflow/templates/deployments)
-    - File [numaflow-controller.yaml](charts/numaflow/templates/deployments/numaflow-controller.yaml) should be updated with [numaflow-controller.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/controller-manager/controller-manager-deployment.yaml)
-    - File [numaflow-server.yaml](charts/numaflow/templates/deployments/numaflow-server.yaml) should be updated with [numaflow-server.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/numaflow-server/numaflow-server-deployment.yaml)
-    - FIle [numaflow-dex-server.yaml](charts/numaflow/templates/deployments/numaflow-dex-server.yaml) should be updated with [numaflow-dex-server.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/dex/numaflow-dex-server-deployment.yaml)
-    - File [numaflow-webhook.yaml](charts/numaflow/templates/deployments/numaflow-webhook.yaml) should be updated with [numaflow-webhook.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/extensions/webhook/numaflow-webhook-deployment.yaml)
-  - Update the [secrets](./charts/numaflow/templates/secrets)
-    - File [numaflow-dex-secrets.yaml](charts/numaflow/templates/secrets/numaflow-dex-secrets.yaml) should be updated with [numaflow-dex-secret.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/dex/numaflow-dex-secrets.yaml)
-    - File [numaflow-server-secrets.yaml](charts/numaflow/templates/secrets/numaflow-server-secrets.yaml) should be updated with [numaflow-server-secrets.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/numaflow-server/numaflow-server-secrets.yaml)
-  - Update the [services](./charts/numaflow/templates/services)
-    - File [numaflow-dex-server.yaml](charts/numaflow/templates/services/numaflow-dex-server.yaml) should be updated with [numaflow-dex-server.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/dex/numaflow-dex-server-service.yaml)
-    - File [numaflow-server.yaml](charts/numaflow/templates/services/numaflow-server.yaml) should be updated with [numaflow-server.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/base/numaflow-server/numaflow-server-service.yaml)
-    - File [numaflow-webhook.yaml](charts/numaflow/templates/services/numaflow-webhook.yaml) should be updated with [numaflow-webhook.yaml](https://github.com/numaproj/numaflow/blob/v1.5.1/config/extensions/webhook/numaflow-webhook-sa.yaml)
+This bumps `version`/`appVersion` in `Chart.yaml`, updates the image `tag` in `values.yaml`, and pulls fresh CRDs, RBAC, and ServiceAccount definitions from upstream.
 
-**Step 4:**
-- Verify the changes by running below helm command in local k8s cluster
+**Step 2: sync the mirrored chart files**
+
 ```
+NUMAFLOW_VERSION=vx.y.z make sync-mirrored-files
+```
+
+This compares each manually-mirrored file (the 15 configmaps, deployments, secrets, and services tracked in [`upgrade/internal/mirror/registry.go`](upgrade/internal/mirror/registry.go)) against `numaproj/numaflow` at the previous and new versions, applies upstream changes onto the templated chart copies via a 3-way merge, and writes the result.
+
+By default the run is dry: every clean merge is written to `upgrade/.merge-rejects/<file>.merged`, and any conflict is written to `upgrade/.merge-rejects/<file>.conflict`. Review the output, then re-run with `--apply` to write the clean merges back to the chart:
+
+```
+NUMAFLOW_VERSION=vx.y.z make sync-mirrored-files SYNC_FLAGS=--apply
+```
+
+Conflicts (`<<<<<<< / ||||||| / ======= / >>>>>>>` markers) require human resolution: open the `*.conflict` file, decide whether to keep the chart's templated value or the upstream change, copy the resolved content into the chart file, and delete the marker file.
+
+Useful flags (pass via `SYNC_FLAGS`):
+- `--from-version=vx.y.z` — override the baseline version (defaults to `Chart.yaml`'s `appVersion`). Useful when catching up several releases at once.
+- `--only=file1.yaml,file2.yaml` — restrict the run to a subset of files (basenames).
+
+**Step 3: verify locally**
+
+```
+helm lint charts/numaflow
+helm template charts/numaflow --namespace numaflow-system | head
 helm install numaflow charts/numaflow --namespace numaflow-system --create-namespace
 ```
 
-**Step 5:**
-- Create a Pull Request against `main` branch and wait for it to get merged, Once it's merged, `CI` will publish the new helm chart release [here](https://github.com/numaproj/helm-charts/releases).
+**Step 4: open a PR**
 
-**Step 6:**
-- Follow [these](./charts/numaflow/README.md) steps to install and verify the helm chart in your cluster.
+Create a Pull Request against `main`. Once it is merged, CI publishes the new helm chart release at <https://github.com/numaproj/helm-charts/releases>.
+
+**Step 5: install from the published chart**
+
+Follow [these](./charts/numaflow/README.md) steps to install and verify the helm chart in your cluster.
 
 Happy helming!!!

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -31,7 +31,7 @@ NUMAFLOW_VERSION=vx.y.z make sync-mirrored-files SYNC_FLAGS=--apply
 Conflicts (`<<<<<<< / ||||||| / ======= / >>>>>>>` markers) require human resolution: open the `*.conflict` file, decide whether to keep the chart's templated value or the upstream change, copy the resolved content into the chart file, and delete the marker file.
 
 Useful flags (pass via `SYNC_FLAGS`):
-- `--from-version=vx.y.z` — override the baseline version (defaults to `Chart.yaml`'s `appVersion`). Useful when catching up several releases at once.
+- `--from-version=vx.y.z` — override the baseline version (defaults to the `appVersion` in the committed `HEAD` `Chart.yaml`, i.e. the previous release, so it is unaffected by the `upgrade-charts` bump in Step 1). Useful when catching up several releases at once.
 - `--only=file1.yaml,file2.yaml` — restrict the run to a subset of files (basenames).
 
 **Step 3: verify locally**

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,27 @@ ifndef NUMAFLOW_VERSION
 $(error NUMAFLOW_VERSION is not set. Please set it to the version you want to release, for example: v1.4.0)
 endif
 
-# Update the numaflow CRDs
-.PHONY: upgrade-charts
-upgrade-charts:
+# Build the upgrade binary. Used as a prerequisite by the workflow targets so
+# they share a single compiled artifact under upgrade/bin/.
+.PHONY: build
+build:
 	cd upgrade && mkdir -p bin && \
-	go build -o bin/upgrade main.go && \
-	NUMAFLOW_VERSION=${NUMAFLOW_VERSION} ./bin/upgrade
+	go build -o bin/upgrade .
+
+# Refresh CRDs, RBAC, ServiceAccounts, Chart.yaml, and values.yaml from the
+# numaflow upstream. Existing flow, unchanged behaviour.
+.PHONY: upgrade-charts
+upgrade-charts: build
+	NUMAFLOW_VERSION=${NUMAFLOW_VERSION} ./upgrade/bin/upgrade upgrade-charts
+
+# Mirror the 15 manually-mirrored chart files (configmaps, deployments,
+# secrets, services) from upstream numaflow. Defaults to dry-run; pass
+# SYNC_FLAGS=--apply once you have reviewed the merge output to write it back.
+#
+# Examples:
+#   NUMAFLOW_VERSION=v1.8.2 make sync-mirrored-files
+#   NUMAFLOW_VERSION=v1.8.2 make sync-mirrored-files SYNC_FLAGS=--apply
+#   NUMAFLOW_VERSION=v1.8.2 make sync-mirrored-files SYNC_FLAGS="--from-version=v1.8.0 --apply"
+.PHONY: sync-mirrored-files
+sync-mirrored-files: build
+	NUMAFLOW_VERSION=${NUMAFLOW_VERSION} ./upgrade/bin/upgrade sync $(SYNC_FLAGS)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,7 +87,7 @@ NUMAFLOW_VERSION=v1.8.0 make sync-mirrored-files
 
 What this does (per file, for all 15 mirrored files):
 
-1. Fetches the upstream blob at `v1.7.5` (chart's previous `appVersion`) **and** at `v1.8.0`.
+1. Fetches the upstream blob at `v1.7.5` (the previous `appVersion`, read from the committed `HEAD` `Chart.yaml` so Step 1's bump does not affect it) **and** at `v1.8.0`.
 2. If both upstream blobs are byte-identical → `no-change`, nothing to do.
 3. Otherwise, runs a 3-way merge:
    - **base** = upstream@v1.7.5
@@ -301,6 +301,10 @@ Install `git`, `diff`, and `patch` on the host. All three are pre-flighted by th
 ### `make upgrade-charts` fails with `Versions are identical`
 
 `Chart.yaml`'s `appVersion` already equals the value you passed in `NUMAFLOW_VERSION`. Either you're trying to re-run a release, or someone bumped `Chart.yaml` out of band. Verify with `cat charts/numaflow/Chart.yaml`.
+
+### `sync-mirrored-files` fails with `--from-version ... equals --to-version`
+
+The baseline and target versions resolved to the same value, so there is nothing to compare. The default baseline is read from the committed `HEAD` `Chart.yaml`; this usually means the `upgrade-charts` bump was already committed (so `HEAD` now carries the new version too), or you passed a `--from-version` equal to the target. Pass an explicit previous version, e.g. `SYNC_FLAGS=--from-version=v1.7.5`.
 
 ### A clean merge in `.merged` looks wrong
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,314 @@
+# Helm Chart Release Playbook
+
+Step-by-step instructions for cutting a new `numaproj/numaflow` Helm chart release in this repo.
+
+Every step is independently runnable and produces output a maintainer can review before moving on. Inline commands assume the new numaflow version is **`v1.8.0`** — substitute as needed for future releases.
+
+> **Quick reference:** see [MAINTAINERS.md](./MAINTAINERS.md) for the condensed summary. This document is the full walkthrough.
+
+---
+
+## What gets automated, what doesn't
+
+| Step                                                              | Automated by                                       |
+| ----------------------------------------------------------------- | -------------------------------------------------- |
+| `Chart.yaml` `version` + `appVersion` bump                        | `make upgrade-charts`                              |
+| `values.yaml` image `tag`                                         | `make upgrade-charts`                              |
+| CRDs, RBAC, ServiceAccounts                                       | `make upgrade-charts`                              |
+| Configmaps, Deployments, Secrets, Services (templated mirror)     | `make sync-mirrored-files`                         |
+| Merge-conflict resolution between upstream changes and chart code | **Manual** — review `upgrade/.merge-rejects/`      |
+| `README.md` version-compatibility table                           | **Manual** — add one row                           |
+| Local install verification                                        | **Manual** — `helm lint` / `helm template` / `helm install` |
+| Opening + reviewing the PR                                        | **Manual**                                         |
+| Publishing the chart to GitHub Releases / `gh-pages`              | CI on merge to `main` (chart-releaser-action)      |
+
+---
+
+## Prerequisites
+
+- Working tree on `main`, clean and up to date with `origin/main`.
+- Numaflow release tag (e.g. `v1.8.0`) is published at <https://github.com/numaproj/numaflow/releases> — the tool will fail fast if it isn't.
+- Local tools on `PATH`: `git`, `diff`, `patch`, `go` (>= 1.24), `helm` (>= 3.14).
+- Optional: a local k8s cluster (`kind` or `minikube`) for the install check in Step 6. If you don't have one, CI's `lint-test` job will cover install verification on the PR.
+
+```bash
+# Sanity check
+which git diff patch go helm
+git status                       # expect: clean
+git pull --ff-only origin main
+```
+
+---
+
+## Step 0 — create a release branch
+
+```bash
+git checkout -b prep-v1.8.0-release
+```
+
+This matches the pattern from prior releases (commits `ce48a7b`, `da10eed`, `bb33931`). The branch name encodes the numaflow version, not the chart version, so it stays readable across major/minor/patch bumps.
+
+---
+
+## Step 1 — refresh the auto-managed files
+
+```bash
+NUMAFLOW_VERSION=v1.8.0 make upgrade-charts
+```
+
+What this does:
+
+1. Verifies `v1.8.0` exists on `github.com/numaproj/numaflow` via the GitHub releases API. If the tag is missing, you get a clear `Version check failed` error and the tool exits — nothing has been modified yet.
+2. Rewrites `charts/numaflow/Chart.yaml`:
+   - `appVersion` → `1.8.0`
+   - `version` → bumped per the chart's own semver rule (major numaflow bump → chart major, minor numaflow bump → chart minor, patch numaflow bump → chart patch). For `1.7.5 → 1.8.0` (minor bump) the chart version goes from `0.4.6 → 0.5.0`.
+3. Rewrites `charts/numaflow/values.yaml`: image `tag: v1.8.0`.
+4. Pulls fresh CRDs into `charts/numaflow/crds/` (5 files).
+5. Pulls fresh RBAC into `charts/numaflow/templates/rbac/{cluster-scoped,namespaced}/` (17 files).
+6. Pulls fresh ServiceAccounts into `charts/numaflow/templates/serviceaccounts/` (4 files).
+
+**After running, review:**
+
+```bash
+git status
+git diff --stat
+git diff charts/numaflow/Chart.yaml charts/numaflow/values.yaml
+```
+
+The Chart.yaml/values.yaml diff should be tiny (3 lines). RBAC/CRD/SA files may show whitespace-only or trailing-newline diffs even in releases where upstream didn't change them — visually scan each before moving on.
+
+---
+
+## Step 2 — dry-run the mirror sync
+
+```bash
+NUMAFLOW_VERSION=v1.8.0 make sync-mirrored-files
+```
+
+What this does (per file, for all 15 mirrored files):
+
+1. Fetches the upstream blob at `v1.7.5` (chart's previous `appVersion`) **and** at `v1.8.0`.
+2. If both upstream blobs are byte-identical → `no-change`, nothing to do.
+3. Otherwise, runs a 3-way merge:
+   - **base** = upstream@v1.7.5
+   - **theirs** = upstream@v1.8.0
+   - **ours** = chart's templated copy (Helm expressions are tokenized for the merge then restored)
+4. Writes the result to `upgrade/.merge-rejects/<filename>.merged` (clean) or `<filename>.conflict` (with `<<<<<<< / ||||||| / ======= / >>>>>>>` markers).
+
+By default the run is **dry** — clean merges are not applied to the chart files. The summary table at the end shows the per-file outcome and the exit code is non-zero if any file ended in conflict.
+
+```text
+Mirror sync summary
+===================
+  no-change:        N
+  applied:          0
+  ready:            M     ← clean merges waiting to be applied
+  conflict:         K     ← review and resolve manually
+  upstream-missing: 0
+  errors:           0
+```
+
+**Flags you may want (pass via `SYNC_FLAGS=...`):**
+
+- `--from-version=vX.Y.Z` — override the baseline. Useful when catching up multiple releases at once (e.g. you skipped `v1.7.6`).
+- `--only=numaflow-controller.yaml,numaflow-server.yaml` — restrict the run to specific basenames for incremental work.
+
+---
+
+## Step 3 — review the dry run
+
+```bash
+ls upgrade/.merge-rejects/
+```
+
+For each entry in that directory:
+
+### `*.merged` — clean merges proposed by the tool
+
+```bash
+diff -u charts/numaflow/templates/<path-from-registry>/<file>.yaml \
+        upgrade/.merge-rejects/<file>.merged
+```
+
+Verify the diff matches your expectation of what upstream changed. The tool preserves Helm templating (`{{ ... }}`, `{{- if }}` blocks, the labels include, the `{{ .Release.Namespace }}` line) — anything outside those should reflect upstream's edits.
+
+### `*.conflict` — files needing manual resolution
+
+```bash
+less upgrade/.merge-rejects/<file>.conflict
+```
+
+Conflict regions look like:
+
+```text
+<<<<<<< ours
+   <what the chart currently has (with templates restored)>
+||||||| base
+   <what upstream had at the previous version>
+=======
+   <what upstream has at the new version>
+>>>>>>> theirs
+```
+
+Decide per region:
+
+- **Take theirs** if the chart was just mirroring upstream verbatim and the upstream change is correct for the chart too.
+- **Take ours** if the chart deliberately diverges (e.g. a key was templated to support a `--set` override that upstream's literal default doesn't capture).
+- **Hybrid** if the answer is "both" — for example, accept upstream's added key but keep our existing templated key untouched.
+
+To resolve:
+1. Edit the `.conflict` file, deleting the marker lines and choosing/blending content as above.
+2. Copy the resolved content over the corresponding chart file:
+   ```bash
+   cp upgrade/.merge-rejects/<file>.conflict charts/numaflow/templates/<dir>/<file>.yaml
+   ```
+3. Delete the rejects file:
+   ```bash
+   rm upgrade/.merge-rejects/<file>.conflict
+   ```
+
+**Known limitation — adjacency false positives:** when upstream changes a line that sits within ~3 rows of a line the chart has templated, git's xdiff bundles both into one hunk and reports a conflict even though the changes don't actually overlap. The "Take ours" half of the conflict region is the chart's existing line; the "Take theirs" half is upstream's change to a *different* line. Both can be accepted; the conflict just couldn't be auto-resolved because the hunks were too close together. See `TestThreeWayMerge_AdjacencyLimitation` in `upgrade/internal/mirror/threeway_test.go` for the canonical example.
+
+---
+
+## Step 4 — apply the clean merges
+
+Once the dry-run output looks right and any conflicts have been resolved by hand:
+
+```bash
+NUMAFLOW_VERSION=v1.8.0 make sync-mirrored-files SYNC_FLAGS=--apply
+```
+
+This re-runs the sync, but this time clean merges are written back to the chart files. Files you already resolved by hand in Step 3 should now report `no-change` (because your hand-resolved content matches what upstream wants, or because you accepted upstream's version directly).
+
+If any file still reports `conflict` after Step 3, you missed one — go back, resolve, repeat.
+
+```bash
+git diff --stat charts/numaflow/templates/
+```
+
+Should show small focused changes; nothing in `crds/`, `rbac/`, or `serviceaccounts/` here (those were handled in Step 1).
+
+---
+
+## Step 5 — update `README.md`
+
+The version-compatibility table at the repo root is not auto-updated. Add a new row at the top of the table (just below the column headers, above the existing `0.4.5 / 1.7.5` row):
+
+```text
+numaproj/numaflow       0.5.0           1.8.0           A Helm chart for installing Numaflow in Kubernetes
+```
+
+Use the chart version that the tool wrote to `Chart.yaml` in Step 1 (`grep '^version:' charts/numaflow/Chart.yaml`) — it may not always be the value you guessed.
+
+```bash
+git diff README.md
+```
+
+---
+
+## Step 6 — local verification
+
+### 6a. Lint
+
+```bash
+helm lint charts/numaflow
+```
+
+Should print `0 chart(s) failed`.
+
+### 6b. Render
+
+```bash
+helm template charts/numaflow --namespace numaflow-system | head -80
+helm template charts/numaflow --namespace numaflow-system \
+  | grep -E 'image:|appVersion'
+```
+
+Verify:
+- No template errors.
+- Controller, server, dex-server, and webhook deployments all reference `quay.io/numaproj/numaflow:v1.8.0` (or `numaflow-server:v1.8.0` where appropriate).
+
+### 6c. Install in a local cluster (optional but recommended)
+
+```bash
+helm install numaflow charts/numaflow \
+  --namespace numaflow-system --create-namespace
+kubectl -n numaflow-system get pods
+kubectl -n numaflow-system get deploy numaflow-controller \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+helm uninstall numaflow -n numaflow-system
+kubectl delete ns numaflow-system
+```
+
+All pods should reach `Running`. If you can't run a cluster locally, the PR's `lint-test` CI job exercises the same path on a KinD cluster.
+
+---
+
+## Step 7 — open the PR
+
+```bash
+git status                       # confirm: only files you reviewed
+git add charts/numaflow/Chart.yaml charts/numaflow/values.yaml \
+        charts/numaflow/crds/ charts/numaflow/templates/ README.md
+# Inspect once more before committing.
+git diff --cached --stat
+git commit -m "chore: v1.8.0 numaflow release"
+git push -u origin prep-v1.8.0-release
+gh pr create --title "chore: v1.8.0 numaflow release" --base main
+```
+
+The commit message format matches the prior releases (`bb33931`, `ce48a7b`, `da10eed`). The PR title should match.
+
+**Before merging, wait for:**
+- `lint-test` workflow ✅ — chart-testing lint + KinD install pass.
+- A maintainer review ✅.
+
+Do **not** stage `upgrade/.merge-rejects/` — that's a scratch directory and is excluded by convention (consider adding to `.gitignore` if it isn't already).
+
+---
+
+## Step 8 — post-merge verification
+
+Once the PR is merged into `main`, the `release` job in `.github/workflows/ci.yaml` runs automatically:
+
+1. `helm/chart-releaser-action@v1.7.0` packages `charts/numaflow/` into a release artifact.
+2. The artifact is published to the `gh-pages` branch and as a GitHub release at <https://github.com/numaproj/helm-charts/releases>.
+
+To verify:
+
+```bash
+gh run watch                                                                    # follow the workflow
+gh release view numaflow-0.5.0 --repo numaproj/helm-charts                      # confirm release exists
+helm repo update numaproj
+helm search repo numaproj/numaflow --versions | head -5
+```
+
+The new chart version should be searchable within a few minutes of merge.
+
+---
+
+## Troubleshooting
+
+### `sync-mirrored-files` reports `upstream-missing`
+
+The mirrored file's upstream path was renamed, moved, or removed at the new numaflow version. Check the upstream repo for the new location, update `upgrade/internal/mirror/registry.go` accordingly, and re-run the sync.
+
+### `sync-mirrored-files` reports an error like `git is required`
+
+Install `git`, `diff`, and `patch` on the host. All three are pre-flighted by the tool.
+
+### `make upgrade-charts` fails with `Versions are identical`
+
+`Chart.yaml`'s `appVersion` already equals the value you passed in `NUMAFLOW_VERSION`. Either you're trying to re-run a release, or someone bumped `Chart.yaml` out of band. Verify with `cat charts/numaflow/Chart.yaml`.
+
+### A clean merge in `.merged` looks wrong
+
+The tokenizer or the merge logic may have mis-handled a Helm syntax variant. Capture the chart file, the upstream-at-vOld blob, and the upstream-at-vNew blob (the tool prints temp paths in verbose mode); open an issue with all three.
+
+---
+
+## What this playbook deliberately doesn't cover
+
+- **Structural drift detection** (L3 in the design doc) — checks whether the chart has *drifted* from upstream over multiple releases (e.g. a missing block from a release nobody synced). Planned as a follow-up; until then, periodically diff each mirrored file against upstream@<latest> manually.
+- **Render-diff sanity check** (L4) — automated comparison of `helm template` output against the prior release's render. Also planned for a follow-up.

--- a/upgrade/common/constant.go
+++ b/upgrade/common/constant.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -10,16 +11,46 @@ const (
 	DefaultLabel  = "	{{- include \"numaflow.labels\" . | nindent 4 }}"
 )
 
+// BaseDir is the absolute path to charts/numaflow/, with a trailing slash so
+// callers can string-concatenate sub-paths the same way they did before.
 var BaseDir string
 
-// init initializes the BaseDir variable with the current working directory
+// init locates charts/numaflow/ by walking up from CWD. This makes the tool
+// runnable from the repo root, from upgrade/, or from any deeper directory —
+// previously it only worked when invoked from upgrade/.
 func init() {
-	dir, err := os.Getwd()
+	cwd, err := os.Getwd()
 	if err != nil {
-		fmt.Println("Error:", err)
+		fmt.Println("Error resolving working directory:", err)
 		return
 	}
-	BaseDir = dir + "/../charts/numaflow/"
+	found, ok := findChartsDir(cwd)
+	if !ok {
+		// Fall back to the legacy behaviour so existing flows keep working
+		// even if the walker doesn't find a chart dir (e.g. tooling invoked
+		// from an entirely unrelated location).
+		BaseDir = cwd + "/../charts/numaflow/"
+		return
+	}
+	BaseDir = found + string(filepath.Separator)
+}
+
+// findChartsDir walks up from start looking for `charts/numaflow/`. Returns
+// the absolute path to that directory (no trailing separator) and true on
+// success.
+func findChartsDir(start string) (string, bool) {
+	dir := start
+	for {
+		candidate := filepath.Join(dir, "charts", "numaflow")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
 }
 
 const (

--- a/upgrade/common/http.go
+++ b/upgrade/common/http.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-const rateLimitMessage = "HTTP Request Failed with Status: 429 Too Many Requests"
-
 // Download fetches the contents of url, retrying on HTTP 429. It returns the
 // response body on success and the last error observed after all retries on
 // failure. Non-429 errors (including 404) fail fast on the first attempt.

--- a/upgrade/common/http.go
+++ b/upgrade/common/http.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const rateLimitMessage = "HTTP Request Failed with Status: 429 Too Many Requests"
+
+// Download fetches the contents of url, retrying on HTTP 429. It returns the
+// response body on success and the last error observed after all retries on
+// failure. Non-429 errors (including 404) fail fast on the first attempt.
+//
+// Retry timing is preserved verbatim from the previous downloadFileDataWithRetry
+// implementation to avoid changing observable behaviour while extracting the
+// helper.
+func Download(url string) (string, error) {
+	const maxRetries = 3
+	var lastErr error
+	for i := 0; i < maxRetries; i++ {
+		data, err := DownloadOnce(url)
+		if err == nil {
+			return data, nil
+		}
+		lastErr = err
+		if !strings.Contains(err.Error(), "429") {
+			break
+		}
+		time.Sleep(time.Duration(2 << (5 * i)))
+	}
+	return "", fmt.Errorf("failed to download %s after retries: %w", url, lastErr)
+}
+
+// DownloadOnce performs a single GET against url with no retry logic. It is
+// exported so callers that need to inspect status codes themselves (e.g.
+// IsVersionExists, which expects a 404 to mean "no such tag") can use it
+// directly.
+func DownloadOnce(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("error fetching URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP Request Failed with Status: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response data: %w", err)
+	}
+
+	return string(data), nil
+}

--- a/upgrade/internal/common.go
+++ b/upgrade/internal/common.go
@@ -2,11 +2,8 @@ package internal
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/numaproj/helm-charts/upgrade/common"
 )
@@ -30,7 +27,7 @@ func updateFiles(localFilePath, url, numaflowVersion string, namespaced bool) er
 		lastLine = originalLines[len(originalLines)-1]
 	}
 
-	latestData, err := downloadFileDataWithRetry(common.GithubBaseURL + numaflowVersion + url)
+	latestData, err := common.Download(common.GithubBaseURL + numaflowVersion + url)
 	if err != nil {
 		return fmt.Errorf("error fetching latest data for file: %s, err:%v", localFilePath, err)
 	}
@@ -135,53 +132,10 @@ func addNamespace(data []string) []string {
 // IsVersionExists checks if the version exists in the GitHub releases
 func IsVersionExists(numaflowVersion string) (bool, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/numaproj/numaflow/releases/tags/%s", numaflowVersion)
-	_, err := downloadFileDataWithRetry(url)
+	_, err := common.Download(url)
 	if err != nil && strings.Contains(err.Error(), "404") {
 		return false, err
 	}
 
 	return true, nil
-}
-
-// DownloadFileData downloads the file data from the given URL
-func DownloadFileData(url string) (string, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", fmt.Errorf("error fetching URL: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Check if the HTTP request was successful
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("HTTP Request Failed with Status: %d %s", resp.StatusCode, resp.Status)
-	}
-
-	// Read the response body
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("error reading response data: %w", err)
-	}
-
-	return string(data), nil
-}
-
-// downloadFileDataWithRetry downloads the file data with retry logic
-func downloadFileDataWithRetry(url string) (string, error) {
-	const maxRetries = 3
-	var err error
-	var data string
-
-	for i := 0; i < maxRetries; i++ {
-		data, err = DownloadFileData(url)
-		if err == nil {
-			return data, nil
-		}
-		if err.Error() == "HTTP Request Failed with Status: 429 Too Many Requests" {
-			time.Sleep(2 << (5 * i)) // Exponential backoff
-			continue                 // Retry on 429 error
-		}
-		break // Break on other errors
-	}
-
-	return "", fmt.Errorf("failed to download file data after %d attempts: %w", maxRetries, err)
 }

--- a/upgrade/internal/mirror/registry.go
+++ b/upgrade/internal/mirror/registry.go
@@ -1,0 +1,109 @@
+// Package mirror automates the maintenance of the 15 chart files that mirror
+// upstream numaflow resources but cannot be auto-overwritten because they
+// carry Helm templating (configmaps, deployments, secrets, services).
+//
+// The package exposes two layers (named L1/L2 in the design doc):
+//
+//   - Layer 1 (upstream.go) — upstream-vs-upstream diff: for each registered
+//     mirror, fetch the upstream blob at both vOld and vNew. If they are
+//     byte-identical there is no work to do.
+//
+//   - Layer 2 (threeway.go) — git 3-way merge: when the upstream blob has
+//     changed, apply that change onto the chart's templated copy using
+//     `git merge-file --diff3` with the chart's Helm expressions first
+//     normalised to deterministic sentinels (tokenize.go) so that templating
+//     does not cause spurious conflicts.
+package mirror
+
+// MirroredFile describes a chart file that is hand-mirrored from upstream
+// numaflow but carries Helm templating, so the existing upgrade tool cannot
+// safely overwrite it.
+type MirroredFile struct {
+	// LocalPath is the path to the chart file, relative to common.BaseDir
+	// (i.e. relative to charts/numaflow/).
+	LocalPath string
+
+	// UpstreamPath is the path inside the numaproj/numaflow repository,
+	// appended to common.GithubBaseURL + <version>.
+	UpstreamPath string
+}
+
+// MirroredFiles is the canonical registry of the chart files that mirror
+// upstream numaflow resources. Entries are ordered by category
+// (configmaps, deployments, secrets, services) and then alphabetically
+// within each category to make additions easy to review.
+//
+// To add a new mirrored file, append an entry here. The `sync` subcommand
+// picks it up automatically — no other code changes are required.
+var MirroredFiles = []MirroredFile{
+	// ---- configmaps ----
+	{
+		LocalPath:    "templates/configmaps/numaflow-cmd-params-config.yaml",
+		UpstreamPath: "/config/base/shared-config/numaflow-cmd-params-config.yaml",
+	},
+	{
+		LocalPath:    "templates/configmaps/numaflow-controller-config.yaml",
+		UpstreamPath: "/config/base/controller-manager/numaflow-controller-config.yaml",
+	},
+	{
+		LocalPath:    "templates/configmaps/numaflow-dex-server-config.yaml",
+		UpstreamPath: "/config/base/dex/numaflow-dex-server-configmap.yaml",
+	},
+	{
+		LocalPath:    "templates/configmaps/numaflow-server-local-user-config.yaml",
+		UpstreamPath: "/config/base/numaflow-server/numaflow-server-local-user-config.yaml",
+	},
+	{
+		LocalPath:    "templates/configmaps/numaflow-server-metrics-proxy-config.yaml",
+		UpstreamPath: "/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml",
+	},
+	{
+		LocalPath:    "templates/configmaps/numaflow-server-rbac-config.yaml",
+		UpstreamPath: "/config/base/numaflow-server/numaflow-server-rbac-config.yaml",
+	},
+
+	// ---- deployments ----
+	{
+		LocalPath:    "templates/deployments/numaflow-controller.yaml",
+		UpstreamPath: "/config/base/controller-manager/controller-manager-deployment.yaml",
+	},
+	{
+		LocalPath:    "templates/deployments/numaflow-dex-server.yaml",
+		UpstreamPath: "/config/base/dex/numaflow-dex-server-deployment.yaml",
+	},
+	{
+		LocalPath:    "templates/deployments/numaflow-server.yaml",
+		UpstreamPath: "/config/base/numaflow-server/numaflow-server-deployment.yaml",
+	},
+	{
+		LocalPath:    "templates/deployments/numaflow-webhook.yaml",
+		UpstreamPath: "/config/extensions/webhook/numaflow-webhook-deployment.yaml",
+	},
+
+	// ---- secrets ----
+	{
+		LocalPath:    "templates/secrets/numaflow-dex-secrets.yaml",
+		UpstreamPath: "/config/base/dex/numaflow-dex-secrets.yaml",
+	},
+	{
+		LocalPath:    "templates/secrets/numaflow-server-secrets.yaml",
+		UpstreamPath: "/config/base/numaflow-server/numaflow-server-secrets.yaml",
+	},
+
+	// ---- services ----
+	{
+		LocalPath:    "templates/services/numaflow-dex-server.yaml",
+		UpstreamPath: "/config/base/dex/numaflow-dex-server-service.yaml",
+	},
+	{
+		LocalPath:    "templates/services/numaflow-server.yaml",
+		UpstreamPath: "/config/base/numaflow-server/numaflow-server-service.yaml",
+	},
+	{
+		// NB: MAINTAINERS.md historically pointed this at numaflow-webhook-sa.yaml,
+		// which is a ServiceAccount, not a Service. The correct upstream is the
+		// webhook service definition.
+		LocalPath:    "templates/services/numaflow-webhook.yaml",
+		UpstreamPath: "/config/extensions/webhook/numaflow-webhook-service.yaml",
+	},
+}

--- a/upgrade/internal/mirror/sync.go
+++ b/upgrade/internal/mirror/sync.go
@@ -1,0 +1,300 @@
+package mirror
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/numaproj/helm-charts/upgrade/common"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+// SyncOptions controls a single `sync` run.
+type SyncOptions struct {
+	// FromVersion is the previous numaflow version the chart was synced
+	// against. If empty, it defaults to the chart's Chart.yaml appVersion
+	// (prefixed with `v`).
+	FromVersion string
+
+	// ToVersion is the new numaflow version to sync to. Required.
+	ToVersion string
+
+	// Apply, when true, writes clean merges back to the chart files. When
+	// false, all merges are written to RejectsDir for human review only.
+	Apply bool
+
+	// Only, when non-empty, restricts processing to mirror files whose
+	// LocalPath basename is in the set. Useful for incremental sync runs.
+	Only []string
+
+	// BaseDir is the chart root (e.g. /path/to/helm-charts/charts/numaflow/).
+	// If empty, common.BaseDir is used.
+	BaseDir string
+
+	// RejectsDir is where conflict outputs and (when !Apply) clean-merge
+	// outputs are written. If empty, defaults to <BaseDir>/../upgrade/.merge-rejects.
+	RejectsDir string
+
+	// Out is the log destination. If nil, defaults to os.Stdout.
+	Out io.Writer
+}
+
+// FileReport describes the result for a single mirrored file.
+type FileReport struct {
+	LocalPath    string
+	UpstreamPath string
+	Status       string // see ReportStatus* constants
+	Detail       string
+}
+
+// Report status strings (kept as plain strings so they appear cleanly in the
+// summary table without further mapping).
+const (
+	ReportStatusNoChange    = "no-change"
+	ReportStatusApplied     = "applied"
+	ReportStatusReady       = "ready (not applied)"
+	ReportStatusConflict    = "conflict"
+	ReportStatusMissing     = "upstream-missing"
+	ReportStatusError       = "error"
+)
+
+// Report aggregates per-file results plus counters used to decide exit code.
+type Report struct {
+	Files     []FileReport
+	NoChange  int
+	Applied   int
+	Ready     int
+	Conflicts int
+	Missing   int
+	Errors    int
+}
+
+// HasFailures reports whether the run should be considered a failure for
+// the purposes of exit code. Conflicts and errors are failures; upstream-
+// missing files are surfaced but not failures (they require maintainer
+// judgement but are not a tool bug).
+func (r Report) HasFailures() bool {
+	return r.Conflicts > 0 || r.Errors > 0
+}
+
+// Run executes a sync pass over the registry according to opts. It returns
+// a Report describing per-file outcomes; the error is non-nil only for
+// pre-flight failures (missing tools, missing version, IO error setting up
+// the workspace) — per-file outcomes are reported via the Report.
+func Run(opts SyncOptions) (Report, error) {
+	if opts.ToVersion == "" {
+		return Report{}, fmt.Errorf("ToVersion is required (pass --to-version or set NUMAFLOW_VERSION)")
+	}
+	if opts.BaseDir == "" {
+		opts.BaseDir = common.BaseDir
+	}
+	if opts.Out == nil {
+		opts.Out = os.Stdout
+	}
+	if opts.RejectsDir == "" {
+		opts.RejectsDir = filepath.Join(filepath.Dir(strings.TrimRight(opts.BaseDir, "/")), "..", "upgrade", ".merge-rejects")
+	}
+
+	if err := EnsureToolsAvailable(); err != nil {
+		return Report{}, err
+	}
+
+	// Resolve FromVersion default from Chart.yaml.
+	if opts.FromVersion == "" {
+		chartFile := filepath.Join(opts.BaseDir, chartutil.ChartfileName)
+		chart, err := chartutil.LoadChartfile(chartFile)
+		if err != nil {
+			return Report{}, fmt.Errorf("read %s: %w", chartFile, err)
+		}
+		if chart.AppVersion == "" {
+			return Report{}, fmt.Errorf("Chart.yaml has empty appVersion; pass --from-version explicitly")
+		}
+		opts.FromVersion = "v" + strings.TrimPrefix(chart.AppVersion, "v")
+		fmt.Fprintf(opts.Out, "info: --from-version not set; using Chart.yaml appVersion %s\n", opts.FromVersion)
+	}
+
+	// Pre-flight: confirm the to-version tag exists upstream so we fail
+	// fast on a typo.
+	if err := verifyVersionExists(opts.ToVersion); err != nil {
+		return Report{}, fmt.Errorf("to-version: %w", err)
+	}
+
+	if err := os.MkdirAll(opts.RejectsDir, 0o755); err != nil {
+		return Report{}, fmt.Errorf("create rejects dir: %w", err)
+	}
+
+	files := filterRegistry(MirroredFiles, opts.Only)
+	if len(files) == 0 {
+		return Report{}, fmt.Errorf("no mirrored files match --only filter %v", opts.Only)
+	}
+
+	fmt.Fprintf(opts.Out, "syncing %d mirrored files from %s -> %s (apply=%v)\n",
+		len(files), opts.FromVersion, opts.ToVersion, opts.Apply)
+
+	var report Report
+	for _, m := range files {
+		fr := processOneFile(opts, m)
+		report.Files = append(report.Files, fr)
+		switch fr.Status {
+		case ReportStatusNoChange:
+			report.NoChange++
+		case ReportStatusApplied:
+			report.Applied++
+		case ReportStatusReady:
+			report.Ready++
+		case ReportStatusConflict:
+			report.Conflicts++
+		case ReportStatusMissing:
+			report.Missing++
+		case ReportStatusError:
+			report.Errors++
+		}
+	}
+
+	writeSummary(opts.Out, report, opts)
+	return report, nil
+}
+
+func filterRegistry(all []MirroredFile, only []string) []MirroredFile {
+	if len(only) == 0 {
+		return all
+	}
+	want := map[string]bool{}
+	for _, name := range only {
+		want[name] = true
+	}
+	var out []MirroredFile
+	for _, m := range all {
+		if want[filepath.Base(m.LocalPath)] {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// processOneFile runs L1 then L2 for a single mirrored file and produces a
+// FileReport. It writes any conflict/merge output to RejectsDir and, if
+// Apply is set and the merge was clean, also writes the merged content back
+// to the chart file.
+func processOneFile(opts SyncOptions, m MirroredFile) FileReport {
+	rep := FileReport{LocalPath: m.LocalPath, UpstreamPath: m.UpstreamPath}
+
+	up := FetchUpstreamPair(m, opts.FromVersion, opts.ToVersion)
+	switch up.Status {
+	case StatusNoChange:
+		rep.Status = ReportStatusNoChange
+		return rep
+	case StatusUpstreamMissing:
+		rep.Status = ReportStatusMissing
+		rep.Detail = up.Err.Error()
+		fmt.Fprintf(opts.Out, "  %s: upstream missing — %v\n", m.LocalPath, up.Err)
+		return rep
+	case StatusError:
+		rep.Status = ReportStatusError
+		rep.Detail = up.Err.Error()
+		fmt.Fprintf(opts.Out, "  %s: error fetching upstream — %v\n", m.LocalPath, up.Err)
+		return rep
+	case StatusChanged:
+		// fall through to merge
+	}
+
+	chartPath := filepath.Join(opts.BaseDir, m.LocalPath)
+	chartCopy, err := os.ReadFile(chartPath)
+	if err != nil {
+		rep.Status = ReportStatusError
+		rep.Detail = err.Error()
+		fmt.Fprintf(opts.Out, "  %s: read chart file — %v\n", m.LocalPath, err)
+		return rep
+	}
+
+	merge := ThreeWayMerge(chartCopy, up.BaseBlob, up.HeadBlob)
+	switch merge.Outcome {
+	case MergeClean:
+		if opts.Apply {
+			if err := os.WriteFile(chartPath, merge.Merged, 0o644); err != nil {
+				rep.Status = ReportStatusError
+				rep.Detail = err.Error()
+				fmt.Fprintf(opts.Out, "  %s: write applied merge — %v\n", m.LocalPath, err)
+				return rep
+			}
+			rep.Status = ReportStatusApplied
+			fmt.Fprintf(opts.Out, "  %s: clean merge applied\n", m.LocalPath)
+		} else {
+			out := filepath.Join(opts.RejectsDir, filepath.Base(m.LocalPath)+".merged")
+			if err := os.WriteFile(out, merge.Merged, 0o644); err != nil {
+				rep.Status = ReportStatusError
+				rep.Detail = err.Error()
+				fmt.Fprintf(opts.Out, "  %s: write merged output — %v\n", m.LocalPath, err)
+				return rep
+			}
+			rep.Status = ReportStatusReady
+			rep.Detail = out
+			fmt.Fprintf(opts.Out, "  %s: clean merge ready (not applied) — %s\n", m.LocalPath, out)
+		}
+	case MergeConflict:
+		out := filepath.Join(opts.RejectsDir, filepath.Base(m.LocalPath)+".conflict")
+		if err := os.WriteFile(out, merge.Merged, 0o644); err != nil {
+			rep.Status = ReportStatusError
+			rep.Detail = err.Error()
+			fmt.Fprintf(opts.Out, "  %s: write conflict output — %v\n", m.LocalPath, err)
+			return rep
+		}
+		rep.Status = ReportStatusConflict
+		rep.Detail = fmt.Sprintf("%d conflict region(s) -> %s", merge.NumConflicts, out)
+		fmt.Fprintf(opts.Out, "  %s: %s\n", m.LocalPath, rep.Detail)
+	case MergeErrored:
+		rep.Status = ReportStatusError
+		rep.Detail = merge.Err.Error()
+		fmt.Fprintf(opts.Out, "  %s: merge error — %v\n", m.LocalPath, merge.Err)
+	}
+	return rep
+}
+
+// verifyVersionExists checks the GitHub releases endpoint for the given tag.
+// This duplicates internal.IsVersionExists in spirit but keeps the mirror
+// package free of an internal/internal import path quirk.
+func verifyVersionExists(version string) error {
+	url := fmt.Sprintf("https://api.github.com/repos/numaproj/numaflow/releases/tags/%s", version)
+	_, err := common.Download(url)
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return fmt.Errorf("numaflow tag %s does not exist on github.com/numaproj/numaflow", version)
+	}
+	return nil
+}
+
+// writeSummary prints a tidy markdown-friendly summary at the end of a run.
+func writeSummary(out io.Writer, r Report, opts SyncOptions) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Mirror sync summary")
+	fmt.Fprintln(out, "===================")
+	fmt.Fprintf(out, "  no-change:        %d\n", r.NoChange)
+	fmt.Fprintf(out, "  applied:          %d\n", r.Applied)
+	fmt.Fprintf(out, "  ready:            %d\n", r.Ready)
+	fmt.Fprintf(out, "  conflict:         %d\n", r.Conflicts)
+	fmt.Fprintf(out, "  upstream-missing: %d\n", r.Missing)
+	fmt.Fprintf(out, "  errors:           %d\n", r.Errors)
+	fmt.Fprintln(out)
+
+	// Per-file table, sorted by LocalPath for stable output.
+	sorted := make([]FileReport, len(r.Files))
+	copy(sorted, r.Files)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].LocalPath < sorted[j].LocalPath })
+	for _, f := range sorted {
+		line := fmt.Sprintf("  %-20s %s", f.Status, f.LocalPath)
+		if f.Detail != "" && f.Status != ReportStatusNoChange {
+			line += "    " + f.Detail
+		}
+		fmt.Fprintln(out, line)
+	}
+
+	if r.HasFailures() {
+		fmt.Fprintf(out, "\nresult: FAILED (%d conflict, %d error) — review %s\n", r.Conflicts, r.Errors, opts.RejectsDir)
+	} else if !opts.Apply && r.Ready > 0 {
+		fmt.Fprintf(out, "\nresult: OK — review proposed merges under %s; re-run with --apply to write them back to the chart\n", opts.RejectsDir)
+	} else {
+		fmt.Fprintln(out, "\nresult: OK")
+	}
+}

--- a/upgrade/internal/mirror/sync.go
+++ b/upgrade/internal/mirror/sync.go
@@ -1,9 +1,11 @@
 package mirror
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -15,8 +17,11 @@ import (
 // SyncOptions controls a single `sync` run.
 type SyncOptions struct {
 	// FromVersion is the previous numaflow version the chart was synced
-	// against. If empty, it defaults to the chart's Chart.yaml appVersion
-	// (prefixed with `v`).
+	// against. If empty, it defaults to the appVersion recorded in the
+	// committed (HEAD) Chart.yaml, prefixed with `v`. HEAD is used rather than
+	// the working tree because the documented release flow runs
+	// `upgrade-charts` first, which rewrites the working-tree appVersion to the
+	// new version.
 	FromVersion string
 
 	// ToVersion is the new numaflow version to sync to. Required.
@@ -53,12 +58,12 @@ type FileReport struct {
 // Report status strings (kept as plain strings so they appear cleanly in the
 // summary table without further mapping).
 const (
-	ReportStatusNoChange    = "no-change"
-	ReportStatusApplied     = "applied"
-	ReportStatusReady       = "ready (not applied)"
-	ReportStatusConflict    = "conflict"
-	ReportStatusMissing     = "upstream-missing"
-	ReportStatusError       = "error"
+	ReportStatusNoChange = "no-change"
+	ReportStatusApplied  = "applied"
+	ReportStatusReady    = "ready (not applied)"
+	ReportStatusConflict = "conflict"
+	ReportStatusMissing  = "upstream-missing"
+	ReportStatusError    = "error"
 )
 
 // Report aggregates per-file results plus counters used to decide exit code.
@@ -102,18 +107,38 @@ func Run(opts SyncOptions) (Report, error) {
 		return Report{}, err
 	}
 
-	// Resolve FromVersion default from Chart.yaml.
+	// Resolve FromVersion default from the committed (HEAD) Chart.yaml.
+	//
+	// We deliberately read HEAD rather than the working tree: the documented
+	// release flow runs `upgrade-charts` first, which rewrites the working-tree
+	// appVersion to the *new* version. Reading that back would make from==to
+	// and silently turn the whole sync into a no-op. HEAD still carries the
+	// previous release's appVersion.
 	if opts.FromVersion == "" {
-		chartFile := filepath.Join(opts.BaseDir, chartutil.ChartfileName)
-		chart, err := chartutil.LoadChartfile(chartFile)
+		appVersion, err := appVersionFromGitHEAD(opts.BaseDir)
 		if err != nil {
-			return Report{}, fmt.Errorf("read %s: %w", chartFile, err)
+			return Report{}, fmt.Errorf("resolve default --from-version from git HEAD: %w; pass --from-version explicitly", err)
 		}
-		if chart.AppVersion == "" {
-			return Report{}, fmt.Errorf("Chart.yaml has empty appVersion; pass --from-version explicitly")
+		if appVersion == "" {
+			return Report{}, fmt.Errorf("HEAD Chart.yaml has empty appVersion; pass --from-version explicitly")
 		}
-		opts.FromVersion = "v" + strings.TrimPrefix(chart.AppVersion, "v")
-		fmt.Fprintf(opts.Out, "info: --from-version not set; using Chart.yaml appVersion %s\n", opts.FromVersion)
+		opts.FromVersion = "v" + strings.TrimPrefix(appVersion, "v")
+		fmt.Fprintf(opts.Out, "info: --from-version not set; using HEAD Chart.yaml appVersion %s\n", opts.FromVersion)
+	}
+
+	// Normalise both versions to a leading `v` so the guard below and the
+	// downstream upstream URLs are consistent regardless of how the caller
+	// spelled them.
+	opts.FromVersion = "v" + strings.TrimPrefix(opts.FromVersion, "v")
+	opts.ToVersion = "v" + strings.TrimPrefix(opts.ToVersion, "v")
+
+	// Guard: from == to means there is nothing to diff. Most commonly this
+	// happens when the `upgrade-charts` bump has already been committed (so
+	// HEAD carries the new version too), or --from-version was set equal to
+	// --to-version by hand. Fail loudly rather than reporting every file as
+	// no-change.
+	if opts.FromVersion == opts.ToVersion {
+		return Report{}, fmt.Errorf("--from-version (%s) equals --to-version (%s); nothing to compare — pass an explicit --from-version for the previous release", opts.FromVersion, opts.ToVersion)
 	}
 
 	// Pre-flight: confirm the to-version tag exists upstream so we fail
@@ -251,6 +276,46 @@ func processOneFile(opts SyncOptions, m MirroredFile) FileReport {
 		fmt.Fprintf(opts.Out, "  %s: merge error — %v\n", m.LocalPath, merge.Err)
 	}
 	return rep
+}
+
+// appVersionFromGitHEAD returns the appVersion recorded in the committed
+// (HEAD) copy of charts/numaflow/Chart.yaml — i.e. the value before any
+// working-tree bump by `upgrade-charts`. baseDir is used only as the git
+// working directory; the path passed to `git show` is repo-root relative so
+// the lookup works regardless of where the binary was invoked from.
+//
+// git availability is guaranteed by EnsureToolsAvailable, which Run calls
+// before reaching here.
+func appVersionFromGitHEAD(baseDir string) (string, error) {
+	rel := "charts/numaflow/" + chartutil.ChartfileName
+	cmd := exec.Command("git", "show", "HEAD:"+rel)
+	cmd.Dir = baseDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git show HEAD:%s: %w (stderr: %s)", rel, err, strings.TrimSpace(stderr.String()))
+	}
+
+	// Reuse chartutil's loader (via a temp file) so parsing semantics match
+	// the working-tree path exactly.
+	tmp, err := os.CreateTemp("", "chart-head-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("create temp chart file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("write temp chart file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close temp chart file: %w", err)
+	}
+	chart, err := chartutil.LoadChartfile(tmp.Name())
+	if err != nil {
+		return "", fmt.Errorf("parse HEAD Chart.yaml: %w", err)
+	}
+	return chart.AppVersion, nil
 }
 
 // verifyVersionExists checks the GitHub releases endpoint for the given tag.

--- a/upgrade/internal/mirror/threeway.go
+++ b/upgrade/internal/mirror/threeway.go
@@ -1,0 +1,275 @@
+package mirror
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// MergeOutcome describes the result of merging upstream changes onto the
+// chart's templated copy.
+type MergeOutcome int
+
+const (
+	MergeOutcomeUnknown MergeOutcome = iota
+	// MergeClean means the upstream change applied without conflict.
+	MergeClean
+	// MergeConflict means the merge produced conflict markers; the maintainer
+	// must resolve them by hand before applying the result to the chart.
+	MergeConflict
+	// MergeErrored means the underlying tooling failed for an unexpected
+	// reason (binary missing, IO error, etc).
+	MergeErrored
+)
+
+func (o MergeOutcome) String() string {
+	switch o {
+	case MergeClean:
+		return "clean-merge"
+	case MergeConflict:
+		return "conflict"
+	case MergeErrored:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// MergeResult is the L2 output for a single mirrored file.
+type MergeResult struct {
+	Outcome      MergeOutcome
+	Merged       []byte // detokenized result; contains conflict markers when Outcome == MergeConflict
+	NumConflicts int    // number of conflict regions reported by git
+	Err          error
+}
+
+// ThreeWayMerge applies the upstream change (base -> theirs) onto the chart's
+// templated copy. The chart copy is tokenized first so Helm template
+// constructs do not match against upstream literals.
+//
+// To avoid false-positive conflicts where chart-only additions (labels,
+// namespace, includes) sit adjacent to upstream changes, we first compute the
+// chart's "pure addition" hunks against base — content the chart adds that
+// upstream has no opinion on — and apply those hunks to both base and theirs.
+// The 3-way merge then sees inputs where the chart-only structure exists on
+// all three sides, so genuine adjacency is not mistaken for an edit conflict.
+//
+// Real conflicts (chart values a line that upstream is also changing) still
+// produce `<<<<<<< / ||||||| / ======= / >>>>>>>` markers in the output.
+//
+// Call EnsureToolsAvailable once before iterating the registry so missing
+// binaries surface up front.
+func ThreeWayMerge(chartCopy, base, theirs []byte) MergeResult {
+	if bytes.Equal(base, theirs) {
+		tok, subs := Tokenize(chartCopy)
+		return MergeResult{Outcome: MergeClean, Merged: Detokenize(tok, subs)}
+	}
+
+	tokenized, subs := Tokenize(chartCopy)
+
+	scratch, err := os.MkdirTemp("", "mirror-merge-*")
+	if err != nil {
+		return MergeResult{Outcome: MergeErrored, Err: fmt.Errorf("create scratch dir: %w", err)}
+	}
+	defer os.RemoveAll(scratch)
+
+	// Step 1: extract the chart's pure-addition hunks against base. These are
+	// the chart-only lines (labels, namespace, includes, conditional blocks)
+	// that have no upstream counterpart.
+	addPatch, err := chartOnlyAdditionsPatch(scratch, base, tokenized)
+	if err != nil {
+		return MergeResult{Outcome: MergeErrored, Err: err}
+	}
+
+	// Step 2: enrich base and theirs by applying the chart-only additions to
+	// both, producing base' and theirs' that share the chart's structural
+	// additions. If the patch is empty (no chart-only additions), the inputs
+	// pass through unchanged.
+	basePrime, err := applyAdditionsPatch(scratch, "base", base, addPatch)
+	if err != nil {
+		return MergeResult{Outcome: MergeErrored, Err: err}
+	}
+	theirsPrime, err := applyAdditionsPatch(scratch, "theirs", theirs, addPatch)
+	if err != nil {
+		return MergeResult{Outcome: MergeErrored, Err: err}
+	}
+
+	// Step 3: run git merge-file --diff3. Any conflict surfaced here reflects
+	// a real disagreement (chart and upstream both editing the same line).
+	merged, conflicts, runErr := runGitMergeFile(scratch, tokenized, basePrime, theirsPrime)
+	if runErr != nil {
+		return MergeResult{Outcome: MergeErrored, Err: runErr}
+	}
+
+	merged = Detokenize(merged, subs)
+	if conflicts > 0 {
+		return MergeResult{Outcome: MergeConflict, Merged: merged, NumConflicts: conflicts}
+	}
+	return MergeResult{Outcome: MergeClean, Merged: merged}
+}
+
+// chartOnlyAdditionsPatch computes the diff base -> tokenized and keeps only
+// hunks consisting purely of additions (no `-` lines). The returned bytes are
+// a valid unified diff that can be fed to `patch` to replay the chart's
+// structural additions onto another file.
+func chartOnlyAdditionsPatch(scratch string, base, tokenized []byte) ([]byte, error) {
+	basePath := filepath.Join(scratch, "base.in")
+	oursPath := filepath.Join(scratch, "ours.in")
+	if err := os.WriteFile(basePath, base, 0o600); err != nil {
+		return nil, fmt.Errorf("write base.in: %w", err)
+	}
+	if err := os.WriteFile(oursPath, tokenized, 0o600); err != nil {
+		return nil, fmt.Errorf("write ours.in: %w", err)
+	}
+
+	// Use -U 0 so each contiguous edit region becomes its own hunk. That way
+	// a hunk containing only `+` lines is a true pure-addition cluster, even
+	// when it sits adjacent to a modification hunk in the chart. With the
+	// default context width, an addition next to a modification gets merged
+	// into a single hunk and the filter would drop both halves.
+	cmd := exec.Command("diff", "-U", "0", basePath, oursPath)
+	out, err := cmd.Output()
+	// `diff` exits 1 when files differ (the normal case) and 0 when
+	// identical. We only care about exit codes >= 2 (real error).
+	if err != nil {
+		if exit, ok := err.(*exec.ExitError); !ok || exit.ExitCode() >= 2 {
+			return nil, fmt.Errorf("diff failed: %w", err)
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return filterAdditionsOnly(out), nil
+}
+
+// filterAdditionsOnly walks a unified diff and keeps only hunks that contain
+// no `-` (deletion) lines. The file-pair header is preserved so the output is
+// still a valid patch.
+func filterAdditionsOnly(diff []byte) []byte {
+	lines := strings.Split(string(diff), "\n")
+	var out []string
+	var header []string
+	var hunk []string
+	var hunkHasDeletion bool
+
+	flushHunk := func() {
+		if len(hunk) == 0 {
+			return
+		}
+		if !hunkHasDeletion {
+			out = append(out, hunk...)
+		}
+		hunk = nil
+		hunkHasDeletion = false
+	}
+
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ "):
+			header = append(header, line)
+		case strings.HasPrefix(line, "@@"):
+			flushHunk()
+			hunk = []string{line}
+		case len(hunk) > 0:
+			if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "--- ") {
+				hunkHasDeletion = true
+			}
+			hunk = append(hunk, line)
+		}
+	}
+	flushHunk()
+
+	if len(out) == 0 {
+		return nil
+	}
+	return []byte(strings.Join(append(header, out...), "\n"))
+}
+
+// applyAdditionsPatch applies the chart's additions to one of base/theirs,
+// producing the enriched input for git merge-file. An empty patch passes the
+// input through unchanged.
+//
+// Rejected hunks (`patch` exit 1) are treated as best-effort enrichment —
+// some additions did not anchor — and we continue with whatever patch
+// produced rather than failing the whole merge. A genuinely broken patch
+// run (exit >= 2) is escalated.
+func applyAdditionsPatch(scratch, label string, target, patch []byte) ([]byte, error) {
+	if len(patch) == 0 {
+		return target, nil
+	}
+	targetPath := filepath.Join(scratch, label+".enriched")
+	patchPath := filepath.Join(scratch, label+".addpatch")
+	rejPath := filepath.Join(scratch, label+".addrej")
+	if err := os.WriteFile(targetPath, target, 0o600); err != nil {
+		return nil, fmt.Errorf("write %s: %w", targetPath, err)
+	}
+	if err := os.WriteFile(patchPath, patch, 0o600); err != nil {
+		return nil, fmt.Errorf("write %s: %w", patchPath, err)
+	}
+	cmd := exec.Command("patch", "--quiet", "-r", rejPath, "-i", patchPath, targetPath)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	if runErr != nil {
+		if exit, ok := runErr.(*exec.ExitError); !ok || exit.ExitCode() >= 2 {
+			return nil, fmt.Errorf("patch %s: %w (stderr: %s)", label, runErr, stderr.String())
+		}
+		// Exit 1: some hunks rejected. Continue with best-effort enrichment.
+	}
+	return os.ReadFile(targetPath)
+}
+
+// runGitMergeFile executes git merge-file --diff3 with the supplied inputs,
+// returning the merged bytes and the number of conflict regions.
+func runGitMergeFile(scratch string, ours, base, theirs []byte) ([]byte, int, error) {
+	oursPath := filepath.Join(scratch, "merge.ours")
+	basePath := filepath.Join(scratch, "merge.base")
+	theirsPath := filepath.Join(scratch, "merge.theirs")
+	for _, p := range []struct {
+		path string
+		data []byte
+	}{{oursPath, ours}, {basePath, base}, {theirsPath, theirs}} {
+		if err := os.WriteFile(p.path, p.data, 0o600); err != nil {
+			return nil, 0, fmt.Errorf("write %s: %w", p.path, err)
+		}
+	}
+	cmd := exec.Command("git", "merge-file", "--diff3",
+		"-L", "ours", "-L", "base", "-L", "theirs",
+		oursPath, basePath, theirsPath)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	merged, readErr := os.ReadFile(oursPath)
+	if readErr != nil {
+		return nil, 0, fmt.Errorf("read merge output: %w", readErr)
+	}
+
+	if runErr != nil {
+		exit, ok := runErr.(*exec.ExitError)
+		if !ok {
+			return nil, 0, fmt.Errorf("git merge-file: %w (stderr: %s)", runErr, stderr.String())
+		}
+		code := exit.ExitCode()
+		if code < 0 {
+			return nil, 0, fmt.Errorf("git merge-file failed: %s", stderr.String())
+		}
+		return merged, code, nil
+	}
+	return merged, 0, nil
+}
+
+// EnsureToolsAvailable verifies that `git`, `diff`, and `patch` are on PATH.
+// Callers should invoke this once before iterating the registry so failures
+// surface up front rather than partway through a sync run.
+func EnsureToolsAvailable() error {
+	for _, tool := range []string{"git", "diff", "patch"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			return fmt.Errorf("%s is required for `sync`: %w", tool, err)
+		}
+	}
+	return nil
+}

--- a/upgrade/internal/mirror/threeway_test.go
+++ b/upgrade/internal/mirror/threeway_test.go
@@ -1,0 +1,190 @@
+package mirror
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func requireTools(t *testing.T) {
+	t.Helper()
+	for _, tool := range []string{"git", "diff", "patch"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not on PATH: %v", tool, err)
+		}
+	}
+}
+
+func TestThreeWayMerge_CleanMerge_UpstreamAddsKey(t *testing.T) {
+	// Upstream adds a new key adjacent to the chart's labels block. The
+	// chart-only addition pre-processing should let this merge cleanly.
+	requireTools(t)
+
+	base := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cmp\ndata:\n  foo: \"1\"\n")
+	theirs := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cmp\ndata:\n  foo: \"1\"\n  bar: \"2\"\n")
+	chart := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cmp\n  labels:\n    {{- include \"numaflow.labels\" . | nindent 4 }}\n  namespace: {{ .Release.Namespace }}\ndata:\n  foo: \"1\"\n")
+
+	res := ThreeWayMerge(chart, base, theirs)
+	if res.Outcome != MergeClean {
+		t.Fatalf("want MergeClean, got %s (err: %v)\nmerged:\n%s", res.Outcome, res.Err, res.Merged)
+	}
+	if !bytes.Contains(res.Merged, []byte("bar: \"2\"")) {
+		t.Fatalf("expected new key bar in merged output:\n%s", res.Merged)
+	}
+	if !bytes.Contains(res.Merged, []byte("{{- include \"numaflow.labels\"")) {
+		t.Fatalf("chart-only labels block missing from merged output:\n%s", res.Merged)
+	}
+	if !bytes.Contains(res.Merged, []byte("{{ .Release.Namespace }}")) {
+		t.Fatalf("chart-only namespace line missing from merged output:\n%s", res.Merged)
+	}
+}
+
+func TestThreeWayMerge_Conflict_BothChangedSameLine(t *testing.T) {
+	// Chart templated a value that upstream is now changing to a new
+	// hardcoded value. Git's 3-way merge should detect this as a real
+	// conflict and produce inline conflict markers.
+	requireTools(t)
+
+	base := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cmp\ndata:\n  foo: \"1\"\n  unrelated: \"x\"\n")
+	theirs := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cmp\ndata:\n  foo: \"2\"\n  unrelated: \"x\"\n")
+	chart := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cmp\ndata:\n  foo: {{ .Values.foo | quote }}\n  unrelated: \"x\"\n")
+
+	res := ThreeWayMerge(chart, base, theirs)
+	if res.Outcome != MergeConflict {
+		t.Fatalf("want MergeConflict, got %s\nmerged:\n%s", res.Outcome, res.Merged)
+	}
+	if res.NumConflicts < 1 {
+		t.Fatalf("expected at least 1 conflict, got %d", res.NumConflicts)
+	}
+	merged := string(res.Merged)
+	for _, marker := range []string{"<<<<<<<", "|||||||", "=======", ">>>>>>>"} {
+		if !strings.Contains(merged, marker) {
+			t.Fatalf("expected conflict marker %q in merged output:\n%s", marker, merged)
+		}
+	}
+	if !strings.Contains(merged, "{{ .Values.foo | quote }}") {
+		t.Fatalf("chart template lost from conflict region:\n%s", merged)
+	}
+	if !strings.Contains(merged, "foo: \"2\"") {
+		t.Fatalf("upstream's value missing from conflict region:\n%s", merged)
+	}
+}
+
+func TestThreeWayMerge_TemplatePassthrough(t *testing.T) {
+	// Upstream changes a non-templated line; the chart's templated lines and
+	// block directives should survive the merge untouched.
+	//
+	// The fixture deliberately places the chart's modified line and upstream's
+	// modified line several rows apart, outside git xdiff's default context
+	// window. This reflects real chart files (chart additions sit in the
+	// metadata block; upstream tweaks sit in the data block) and avoids the
+	// known limitation where two non-overlapping line modifications within a
+	// 3-line window get bundled into one hunk and flagged as a conflict.
+	requireTools(t)
+
+	base := []byte(
+		"data:\n" +
+			"  foo: \"1\"\n" +
+			"  alpha: \"a\"\n" +
+			"  beta: \"b\"\n" +
+			"  gamma: \"g\"\n" +
+			"  shared: \"old\"\n")
+	theirs := []byte(
+		"data:\n" +
+			"  foo: \"1\"\n" +
+			"  alpha: \"a\"\n" +
+			"  beta: \"b\"\n" +
+			"  gamma: \"g\"\n" +
+			"  shared: \"new\"\n")
+	chart := []byte(
+		"data:\n" +
+			"  foo: {{ .Values.foo | quote }}\n" +
+			"  alpha: \"a\"\n" +
+			"  beta: \"b\"\n" +
+			"  gamma: \"g\"\n" +
+			"  shared: \"old\"\n" +
+			"  {{- if .Values.extra.enabled }}\n" +
+			"  extra: \"yes\"\n" +
+			"  {{- end }}\n")
+
+	res := ThreeWayMerge(chart, base, theirs)
+	if res.Outcome != MergeClean {
+		t.Fatalf("want MergeClean, got %s (err: %v)\nmerged:\n%s", res.Outcome, res.Err, res.Merged)
+	}
+	merged := string(res.Merged)
+	if !strings.Contains(merged, "shared: \"new\"") {
+		t.Fatalf("upstream change to `shared` missing:\n%s", merged)
+	}
+	if !strings.Contains(merged, "{{ .Values.foo | quote }}") {
+		t.Fatalf("inline template lost:\n%s", merged)
+	}
+	if !strings.Contains(merged, "{{- if .Values.extra.enabled }}") || !strings.Contains(merged, "{{- end }}") {
+		t.Fatalf("block directives lost:\n%s", merged)
+	}
+}
+
+func TestThreeWayMerge_AdjacencyLimitation(t *testing.T) {
+	// Documents a known limitation: when the chart's modification of an
+	// upstream line and upstream's modification of a different upstream line
+	// sit within git xdiff's context window (~3 lines), they are reported as
+	// a single conflicting hunk even though the lines do not overlap.
+	//
+	// This test pins that behaviour so a future change to the merge strategy
+	// either preserves it intentionally or is caught for review.
+	requireTools(t)
+
+	base := []byte("data:\n  foo: \"1\"\n  shared: \"old\"\n")
+	theirs := []byte("data:\n  foo: \"1\"\n  shared: \"new\"\n")
+	chart := []byte("data:\n  foo: {{ .Values.foo | quote }}\n  shared: \"old\"\n")
+
+	res := ThreeWayMerge(chart, base, theirs)
+	if res.Outcome != MergeConflict {
+		t.Skipf("adjacency no longer produces a false-positive conflict (improvement, not a regression): %s", res.Outcome)
+	}
+	if !strings.Contains(string(res.Merged), "{{ .Values.foo | quote }}") {
+		t.Fatalf("chart template lost in adjacency conflict:\n%s", res.Merged)
+	}
+}
+
+func TestThreeWayMerge_NoUpstreamChange_NoOp(t *testing.T) {
+	// When base == theirs, the chart copy should pass through unchanged.
+	requireTools(t)
+
+	base := []byte("data:\n  foo: \"1\"\n")
+	chart := []byte("data:\n  foo: {{ .Values.foo | quote }}\n")
+
+	res := ThreeWayMerge(chart, base, base)
+	if res.Outcome != MergeClean {
+		t.Fatalf("want MergeClean, got %s", res.Outcome)
+	}
+	if !bytes.Equal(res.Merged, chart) {
+		t.Fatalf("no-op merge altered chart copy\nwant: %s\ngot:  %s", chart, res.Merged)
+	}
+}
+
+func TestFilterAdditionsOnly(t *testing.T) {
+	// Confirm the diff filter keeps pure-addition hunks and drops hunks with
+	// any deletion line.
+	diff := []byte(
+		"--- a/base.in\n" +
+			"+++ b/ours.in\n" +
+			"@@ -1,2 +1,3 @@\n" +
+			" first\n" +
+			"+inserted-only\n" +
+			" second\n" +
+			"@@ -10,2 +11,2 @@\n" +
+			"-deleted\n" +
+			"+replaced\n" +
+			" tail\n")
+	out := filterAdditionsOnly(diff)
+	if !bytes.Contains(out, []byte("inserted-only")) {
+		t.Errorf("addition hunk dropped:\n%s", out)
+	}
+	if bytes.Contains(out, []byte("deleted")) {
+		t.Errorf("modification hunk kept:\n%s", out)
+	}
+	if bytes.Contains(out, []byte("replaced")) {
+		t.Errorf("modification hunk kept:\n%s", out)
+	}
+}

--- a/upgrade/internal/mirror/tokenize.go
+++ b/upgrade/internal/mirror/tokenize.go
@@ -1,0 +1,104 @@
+package mirror
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// Tokenize replaces every Helm template construct in src with a deterministic
+// sentinel that is safe to round-trip through `git merge-file`. It returns the
+// tokenized bytes and a map from sentinel -> original text for use by
+// Detokenize.
+//
+// Two forms are recognised:
+//
+//  1. Inline expressions like `key: {{ .Values.X | quote }}`. The `{{...}}`
+//     run is replaced with `__NFTPLEXPR_<sha1[:8]>__`. The map stores just the
+//     expression text.
+//
+//  2. Lines whose non-whitespace content is entirely template directives, e.g.
+//     `{{- if X }}`, `{{- end }}`, `{{- include "labels" . | nindent 4 }}`.
+//     The whole line is replaced with `<indent># __NFTPLLINE_<sha1[:8]>__` so
+//     that the tokenized YAML remains parseable. The map stores the entire
+//     original line (without its trailing newline).
+//
+// Substituting templates with sentinels means git's line-based merge sees
+// stable identifiers on both the chart and upstream sides for unchanged
+// templated lines, so it only conflicts where upstream and chart genuinely
+// disagree on the same line.
+const (
+	sentinelInlinePrefix = "__NFTPLEXPR_"
+	sentinelBlockPrefix  = "__NFTPLLINE_"
+	sentinelSuffix       = "__"
+)
+
+var (
+	exprRe   = regexp.MustCompile(`\{\{-?[\s\S]*?-?\}\}`)
+	blockRe  = regexp.MustCompile(`^([ \t]*)# (` + regexp.QuoteMeta(sentinelBlockPrefix) + `[0-9a-f]+` + regexp.QuoteMeta(sentinelSuffix) + `)\s*$`)
+	inlineRe = regexp.MustCompile(regexp.QuoteMeta(sentinelInlinePrefix) + `[0-9a-f]+` + regexp.QuoteMeta(sentinelSuffix))
+)
+
+// Tokenize converts a templated chart file into a sentinel-substituted form
+// suitable for `git merge-file`. The returned map records the substitutions
+// so Detokenize can restore the original content exactly.
+func Tokenize(src []byte) ([]byte, map[string]string) {
+	subs := map[string]string{}
+	lines := strings.Split(string(src), "\n")
+	for i, line := range lines {
+		// Block form: the entire non-whitespace content of the line is template
+		// directives. Replace the whole line with a YAML comment sentinel.
+		stripped := exprRe.ReplaceAllString(line, "")
+		if strings.Contains(line, "{{") && strings.TrimSpace(stripped) == "" {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+			h := hash(line)
+			sentinel := sentinelBlockPrefix + h + sentinelSuffix
+			subs[sentinel] = line
+			lines[i] = indent + "# " + sentinel
+			continue
+		}
+		// Inline form: replace each `{{...}}` run individually.
+		lines[i] = exprRe.ReplaceAllStringFunc(line, func(match string) string {
+			h := hash(match)
+			sentinel := sentinelInlinePrefix + h + sentinelSuffix
+			subs[sentinel] = match
+			return sentinel
+		})
+	}
+	return []byte(strings.Join(lines, "\n")), subs
+}
+
+// Detokenize reverses Tokenize: it replaces every sentinel in src with the
+// original text recorded in subs.
+//
+// Block sentinels are detected at line level so they restore the original line
+// verbatim, including the original indent and any trailing whitespace.
+// Inline sentinels are replaced as substrings within the surviving line.
+//
+// Unknown sentinels (not present in subs — for example, if the merge inserted
+// sentinel text from the other side via a hunk we did not write) are left
+// untouched so the caller can flag them.
+func Detokenize(src []byte, subs map[string]string) []byte {
+	lines := strings.Split(string(src), "\n")
+	for i, line := range lines {
+		if m := blockRe.FindStringSubmatch(line); m != nil {
+			if original, ok := subs[m[2]]; ok {
+				lines[i] = original
+				continue
+			}
+		}
+		lines[i] = inlineRe.ReplaceAllStringFunc(line, func(sentinel string) string {
+			if original, ok := subs[sentinel]; ok {
+				return original
+			}
+			return sentinel
+		})
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func hash(s string) string {
+	h := sha1.Sum([]byte(s))
+	return hex.EncodeToString(h[:4])
+}

--- a/upgrade/internal/mirror/tokenize_test.go
+++ b/upgrade/internal/mirror/tokenize_test.go
@@ -1,0 +1,133 @@
+package mirror
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTokenizeDetokenizeRoundtrip_AllMirroredFiles(t *testing.T) {
+	// Round-trip every real mirrored chart file currently in the repo.
+	// This is the hard invariant: Detokenize(Tokenize(x)) must equal x.
+	chartRoot, err := chartRootForTest()
+	if err != nil {
+		t.Fatalf("locating chart root: %v", err)
+	}
+	for _, m := range MirroredFiles {
+		path := filepath.Join(chartRoot, m.LocalPath)
+		original, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", m.LocalPath, err)
+			continue
+		}
+		tokenized, subs := Tokenize(original)
+		restored := Detokenize(tokenized, subs)
+		if !bytes.Equal(original, restored) {
+			t.Errorf("roundtrip mismatch for %s\n--- original ---\n%s\n--- restored ---\n%s",
+				m.LocalPath, hexish(original), hexish(restored))
+		}
+	}
+}
+
+func TestTokenize_ProducesNoTemplateRuns(t *testing.T) {
+	// After tokenisation no `{{` or `}}` should remain — that would mean a
+	// template construct slipped past the regex and would confuse git's
+	// line-based merge.
+	chartRoot, err := chartRootForTest()
+	if err != nil {
+		t.Fatalf("locating chart root: %v", err)
+	}
+	for _, m := range MirroredFiles {
+		original, err := os.ReadFile(filepath.Join(chartRoot, m.LocalPath))
+		if err != nil {
+			t.Errorf("read %s: %v", m.LocalPath, err)
+			continue
+		}
+		tokenized, _ := Tokenize(original)
+		if bytes.Contains(tokenized, []byte("{{")) || bytes.Contains(tokenized, []byte("}}")) {
+			t.Errorf("residual template markers in tokenized %s: %s", m.LocalPath, tokenized)
+		}
+	}
+}
+
+func TestTokenize_Inline(t *testing.T) {
+	src := []byte(`key: {{ .Values.X | quote }}`)
+	tok, subs := Tokenize(src)
+	if bytes.Contains(tok, []byte("{{")) {
+		t.Fatalf("inline expression survived tokenisation: %s", tok)
+	}
+	if !bytes.HasPrefix(tok, []byte("key: __NFTPLEXPR_")) {
+		t.Fatalf("inline sentinel form unexpected: %s", tok)
+	}
+	if !bytes.Equal(Detokenize(tok, subs), src) {
+		t.Fatalf("roundtrip mismatch for inline")
+	}
+}
+
+func TestTokenize_BlockDirective(t *testing.T) {
+	src := []byte(`  {{- if .Values.dexServer.enabled }}` + "\n" +
+		`  key: value` + "\n" +
+		`  {{- end }}`)
+	tok, subs := Tokenize(src)
+	if bytes.Contains(tok, []byte("{{")) {
+		t.Fatalf("block expression survived tokenisation: %s", tok)
+	}
+	if !bytes.Contains(tok, []byte("  # __NFTPLLINE_")) {
+		t.Fatalf("expected block sentinel as YAML comment with indent: %s", tok)
+	}
+	if !bytes.Equal(Detokenize(tok, subs), src) {
+		t.Fatalf("roundtrip mismatch for block")
+	}
+}
+
+func TestTokenize_MultipleInlinePerLine(t *testing.T) {
+	src := []byte(`server.address: "{{ .Values.server.configs.host }}:{{ include "server.configs.port" . }}"`)
+	tok, subs := Tokenize(src)
+	count := bytes.Count(tok, []byte("__NFTPLEXPR_"))
+	if count != 2 {
+		t.Fatalf("want 2 inline sentinels, got %d in %s", count, tok)
+	}
+	if !bytes.Equal(Detokenize(tok, subs), src) {
+		t.Fatalf("roundtrip mismatch for multi-inline")
+	}
+}
+
+func TestTokenize_LeavesPlainTextAlone(t *testing.T) {
+	src := []byte(`apiVersion: v1` + "\n" + `kind: ConfigMap` + "\n" + `# this is a comment`)
+	tok, _ := Tokenize(src)
+	if !bytes.Equal(tok, src) {
+		t.Fatalf("plain text was modified:\n--- before ---\n%s\n--- after ---\n%s", src, tok)
+	}
+}
+
+// chartRootForTest finds charts/numaflow/ by walking up from CWD.
+// Tests run with CWD = upgrade/internal/mirror, so we walk up to repo root.
+func chartRootForTest() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, "charts", "numaflow")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}
+
+// hexish renders a byte slice with visible markers for whitespace so a
+// roundtrip mismatch is easy to read in test output.
+func hexish(b []byte) string {
+	s := string(b)
+	s = strings.ReplaceAll(s, "\t", "→")
+	s = strings.ReplaceAll(s, " ", "·")
+	return s
+}

--- a/upgrade/internal/mirror/upstream.go
+++ b/upgrade/internal/mirror/upstream.go
@@ -1,0 +1,112 @@
+package mirror
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/numaproj/helm-charts/upgrade/common"
+)
+
+// Status is the outcome of fetching the upstream pair for a single mirrored
+// file. It tells the orchestrator whether to run a 3-way merge, skip the
+// file, or surface an error.
+type Status int
+
+const (
+	StatusUnknown Status = iota
+	// StatusNoChange means upstream@vOld and upstream@vNew are byte-identical
+	// (after normalisation). The chart copy needs no update.
+	StatusNoChange
+	// StatusChanged means upstream@vOld and upstream@vNew differ. The chart
+	// copy should be brought up to date via a 3-way merge.
+	StatusChanged
+	// StatusUpstreamMissing means upstream does not have the file at one or
+	// both versions (404). Most commonly: a file that was added in a later
+	// upstream release, or a path that was renamed. The maintainer must
+	// resolve manually.
+	StatusUpstreamMissing
+	// StatusError means the fetch failed for an unexpected reason (network,
+	// rate limit exhaustion, IO).
+	StatusError
+)
+
+func (s Status) String() string {
+	switch s {
+	case StatusNoChange:
+		return "no-change"
+	case StatusChanged:
+		return "changed"
+	case StatusUpstreamMissing:
+		return "upstream-missing"
+	case StatusError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// UpstreamResult is the L1 output for a single mirrored file.
+type UpstreamResult struct {
+	Mirror   MirroredFile
+	Status   Status
+	BaseBlob []byte // upstream@vOld, populated when Status == StatusChanged
+	HeadBlob []byte // upstream@vNew, populated when Status == StatusChanged
+	Err      error
+}
+
+// FetchUpstreamPair downloads the upstream blobs for vOld and vNew, normalises
+// line endings, and reports whether the upstream changed. This is L1 of the
+// design: the primary signal for whether any work is needed on a file.
+func FetchUpstreamPair(m MirroredFile, vOld, vNew string) UpstreamResult {
+	res := UpstreamResult{Mirror: m}
+
+	baseURL := common.GithubBaseURL + vOld + m.UpstreamPath
+	headURL := common.GithubBaseURL + vNew + m.UpstreamPath
+
+	baseStr, err := common.Download(baseURL)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			res.Status = StatusUpstreamMissing
+			res.Err = fmt.Errorf("upstream@%s not found at %s", vOld, m.UpstreamPath)
+			return res
+		}
+		res.Status = StatusError
+		res.Err = fmt.Errorf("fetch %s: %w", baseURL, err)
+		return res
+	}
+
+	headStr, err := common.Download(headURL)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			res.Status = StatusUpstreamMissing
+			res.Err = fmt.Errorf("upstream@%s not found at %s", vNew, m.UpstreamPath)
+			return res
+		}
+		res.Status = StatusError
+		res.Err = fmt.Errorf("fetch %s: %w", headURL, err)
+		return res
+	}
+
+	base := normalizeBlob([]byte(baseStr))
+	head := normalizeBlob([]byte(headStr))
+
+	if bytes.Equal(base, head) {
+		res.Status = StatusNoChange
+		return res
+	}
+
+	res.Status = StatusChanged
+	res.BaseBlob = base
+	res.HeadBlob = head
+	return res
+}
+
+// normalizeBlob strips a UTF-8 BOM and converts CRLF line endings to LF so
+// byte equality reflects content equality rather than incidental encoding
+// differences.
+func normalizeBlob(b []byte) []byte {
+	b = bytes.TrimPrefix(b, []byte{0xEF, 0xBB, 0xBF})
+	b = bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+	return b
+}

--- a/upgrade/main.go
+++ b/upgrade/main.go
@@ -30,8 +30,21 @@ Environment:
 `
 
 func main() {
-	subcommand := "upgrade-charts"
 	args := os.Args[1:]
+
+	// Handle help before subcommand dispatch so `help`, `-h`, and `--help`
+	// all work. They must be checked here because the subcommand extraction
+	// below skips anything starting with `-`, which would otherwise route the
+	// flag forms into the default `upgrade-charts` path.
+	if len(args) > 0 {
+		switch args[0] {
+		case "help", "-h", "--help":
+			fmt.Print(usage)
+			return
+		}
+	}
+
+	subcommand := "upgrade-charts"
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		subcommand = args[0]
 		args = args[1:]
@@ -42,8 +55,6 @@ func main() {
 		runUpgradeCharts()
 	case "sync":
 		runSync(args)
-	case "help", "-h", "--help":
-		fmt.Print(usage)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown subcommand: %s\n\n%s", subcommand, usage)
 		os.Exit(2)

--- a/upgrade/main.go
+++ b/upgrade/main.go
@@ -1,16 +1,59 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/numaproj/helm-charts/upgrade/internal"
+	"github.com/numaproj/helm-charts/upgrade/internal/mirror"
 )
 
+const usage = `upgrade — helm-charts release helper for numaflow
+
+Usage:
+  upgrade [upgrade-charts]          Run the existing CRD/RBAC/SA/Chart.yaml/values.yaml refresh
+                                    (default subcommand; honours NUMAFLOW_VERSION env var)
+  upgrade sync [flags]              Mirror the 15 chart-only-templated files (configmaps,
+                                    deployments, secrets, services) from upstream numaflow
+
+sync flags:
+  --to-version=vX.Y.Z       New numaflow version (defaults to $NUMAFLOW_VERSION)
+  --from-version=vX.Y.Z     Previous numaflow version (defaults to Chart.yaml appVersion)
+  --apply                   Write clean merges back to the chart files (default: dry-run)
+  --only=a.yaml,b.yaml      Restrict to the listed file basenames
+
+Environment:
+  NUMAFLOW_VERSION          New numaflow version; equivalent to --to-version
+`
+
 func main() {
+	subcommand := "upgrade-charts"
+	args := os.Args[1:]
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		subcommand = args[0]
+		args = args[1:]
+	}
+
+	switch subcommand {
+	case "upgrade-charts":
+		runUpgradeCharts()
+	case "sync":
+		runSync(args)
+	case "help", "-h", "--help":
+		fmt.Print(usage)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand: %s\n\n%s", subcommand, usage)
+		os.Exit(2)
+	}
+}
+
+func runUpgradeCharts() {
 	numaflowVersion := os.Getenv("NUMAFLOW_VERSION")
 	if numaflowVersion == "" {
-		log.Fatalln("Numaflow version is required as a command line argument")
+		log.Fatalln("Numaflow version is required (set NUMAFLOW_VERSION)")
 	}
 
 	log.Println("Checking version existence in Numaflow repo...")
@@ -32,4 +75,32 @@ func main() {
 
 	log.Println("\n################### Updating latest data for Service Account ###################")
 	internal.UpdateServiceAccount(numaflowVersion)
+}
+
+func runSync(args []string) {
+	fs := flag.NewFlagSet("sync", flag.ExitOnError)
+	toVersion := fs.String("to-version", os.Getenv("NUMAFLOW_VERSION"), "new numaflow version (default: $NUMAFLOW_VERSION)")
+	fromVersion := fs.String("from-version", "", "previous numaflow version (default: Chart.yaml appVersion)")
+	apply := fs.Bool("apply", false, "write clean merges back to chart files (default: dry-run)")
+	only := fs.String("only", "", "comma-separated basenames to restrict the sync to")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	opts := mirror.SyncOptions{
+		FromVersion: *fromVersion,
+		ToVersion:   *toVersion,
+		Apply:       *apply,
+	}
+	if *only != "" {
+		opts.Only = strings.Split(*only, ",")
+	}
+
+	report, err := mirror.Run(opts)
+	if err != nil {
+		log.Fatalln("sync failed:", err)
+	}
+	if report.HasFailures() {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Introduce a `sync-mirrored` step that:

1. Fetches the upstream blob at chart's previous `appVersion` **and** at version we want to upgrade to.
2. If both upstream blobs are byte-identical → `no-change`, nothing to do.
3. Otherwise, runs a 3-way merge:
   - **base** = upstream@vPrevVersion
   - **theirs** = upstream@vDesiredVersion
   - **ours** = chart's templated copy (Helm expressions are tokenized for the merge then restored)
4. Writes the result to `upgrade/.merge-rejects/<filename>.merged` (clean) or `<filename>.conflict` (with `<<<<<<< / ||||||| / ======= / >>>>>>>` markers).
5. If any conflicts are found, resolve them manually

eg: 

```bash
NUMAFLOW_VERSION=v1.8.0 make sync-mirrored-files
```